### PR TITLE
CLI without commander-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@types/react-test-renderer": "=16.0.3",
     "babel-core": "=7.0.0-bridge.0",
     "babel-jest": "23.6.0",
-    "commander": "^2.19.0",
     "eslint": "=4.19.1",
     "form-data": "=2.3.3",
     "jest": "=23.6.0",

--- a/src/cliParser.ts
+++ b/src/cliParser.ts
@@ -185,7 +185,7 @@ interface OptionLookup {
 }
 
 interface Context {
-    name: string;
+    commandName: string;
     args: string[];
     definition: Definition;
 }
@@ -206,7 +206,7 @@ const readArgAndExecute = (context: Context, printer: Printer): Context => {
     if (isOption(args[0])) {
         const option = optionLookup[args[0]] || throwOptionError(args[0]);
         if (option === helpOption) {
-            printUsage(context.name, context.definition, printer);
+            printUsage(context.commandName, context.definition, printer);
             return {
                 ...context,
                 args: [],
@@ -215,7 +215,7 @@ const readArgAndExecute = (context: Context, printer: Printer): Context => {
         else if (args.length - 1 >= option.args.length) {
             option.action(...args.slice(1, 1 + option.args.length));
             return {
-                name: context.name,
+                commandName: context.commandName,
                 args: args.slice(1 + option.args.length),
                 definition: context.definition,
             };
@@ -231,13 +231,13 @@ const readArgAndExecute = (context: Context, printer: Printer): Context => {
                     }
                     command.actionOrDefinition(...commandArgs);
                     return {
-                        name: command.name,
+                        commandName: command.name,
                         args: args.slice(1 + command.args.length),
                         definition: context.definition,
                     };
                 } else {
                     return {
-                        name: command.name,
+                        commandName: command.name,
                         args: args.slice(1),
                         definition: command.actionOrDefinition,
                     };
@@ -268,7 +268,7 @@ export const parseArguments = (
 
     try {
         let context = {
-            name,
+            commandName: name,
             args: args.slice(2),
             definition,
         };

--- a/src/cliParser.ts
+++ b/src/cliParser.ts
@@ -1,0 +1,283 @@
+const optionNameHumanSeparator = ', ';
+
+type Printer = (...args: any[]) => void;
+
+type Action = (...args: string[]) => void;
+
+interface Option {
+    names: string[];
+    args: string[];
+    description: string;
+    action: Action;
+}
+
+interface Command {
+    name: string;
+    args: string[];
+    description: string;
+    actionOrDefinition: Action | Definition;
+}
+
+interface Definition {
+    options: Option[];
+    commands: Command[];
+}
+
+const isAction = (a: Action | Definition): a is Action => {
+    return (a as Definition).commands === undefined;
+};
+
+interface CommandAdder extends Definition {
+    addCommand: (name: string, description: string, actionOrSubCommand: Action | Definition) => CommandAdder;
+}
+
+interface OptionAdder extends CommandAdder {
+    addOption: (name: string, description: string, action: Action) => OptionAdder;
+}
+
+const defineOption = (nameDef: string, description: string, action: Action): Option => {
+    const optionNameSeparator = '|';
+    const canonicalOptionName = nameDef.replace(optionNameHumanSeparator, optionNameSeparator);
+    const optionArguments = canonicalOptionName.split(' ');
+    const namesPart = optionArguments[0];
+    const names = namesPart.split(optionNameSeparator).map(name => name.trim());
+    const args = optionArguments.slice(1);
+    return {
+        names,
+        args,
+        description,
+        action,
+    };
+};
+
+const defineCommand = (nameDef: string, description: string, actionOrDefinition: Action | Definition): Command => {
+    const nameParts = nameDef.split(' ');
+    const name = nameParts[0];
+    const args = nameParts.slice(1);
+    return {
+        name,
+        args,
+        description,
+        actionOrDefinition,
+    };
+};
+
+export const emptyDefinition = {
+    options: [],
+    commands: [],
+};
+
+const defineProgram = (definition: Definition = emptyDefinition): OptionAdder => {
+    const addBaseOption = (usage: Definition, name: string, description: string, action: Action): OptionAdder => {
+        const newUsage = {
+            ...usage,
+            options: [...usage.options, defineOption(name, description, action)],
+        };
+        return {
+            ...newUsage,
+            addOption: (pName, pDescription, pAction) => addBaseOption(newUsage, pName, pDescription, pAction),
+            addCommand: (pName, pDescription, pAction) => addBaseCommand(newUsage, pName, pDescription, pAction),
+        };
+    };
+    const addBaseCommand = (usage: Definition, name: string, description: string, actionOrDefinition: Action | Definition): CommandAdder => {
+        const newUsage = {
+            ...usage,
+            commands: [...usage.commands, defineCommand(name, description, actionOrDefinition)],
+        };
+        return {
+            ...newUsage,
+            addCommand: (pName, pDescription, pAction) => addBaseCommand(newUsage, pName, pDescription, pAction),
+        };
+    };
+    return {
+        ...definition,
+        addOption: (name, description, action) =>
+            addBaseOption(definition, name, description, action),
+        addCommand: (name, description, action) =>
+            addBaseCommand(definition, name, description, action),
+    };
+};
+
+const helpOption = defineOption('-h, --help', 'output usage information', () => {});
+
+export const addOption = (name: string, description: string, action: Action): OptionAdder => {
+    const definition = {
+        options: [helpOption, defineOption(name, description, action)],
+        commands: [],
+    };
+    return defineProgram(definition);
+};
+
+export const addCommand = (name: string, description: string, actionOrSubCommand: Action | Definition): CommandAdder => {
+    const definition = {
+        options: [helpOption],
+        commands: [defineCommand(name, description, actionOrSubCommand)],
+    };
+    return defineProgram(definition);
+};
+
+const subcommandDescription = (commands: Command[]): string =>
+    '<' + commands.map(command => command.name.split(' ')[0]).join('|') + '>';
+
+const commandArgumentsDescription = (command: Command): string => {
+    if (isAction(command.actionOrDefinition)) {
+        return command.args.join(' ');
+    }
+    if (command.actionOrDefinition.commands.length === 0) {
+        return '';
+    }
+    return subcommandDescription(command.actionOrDefinition.commands);
+};
+
+const padWithSpace = (input: string, width: number): string => {
+    let padded = input;
+    while (padded.length < width) {
+        padded += ' ';
+    }
+    return padded;
+};
+
+const printUsage = (name: string, definition: Definition, printer: Printer) => {
+    printer(`Usage: ${name} [options] ${subcommandDescription(definition.commands)}`);
+    printer('');
+    printer('Options:');
+
+    const namePadding = 46;
+    for (const option of definition.options) {
+        const optionName = option.names.join(optionNameHumanSeparator);
+        printer(`  ${padWithSpace(optionName, namePadding)}${option.description}`);
+    }
+
+    printer('');
+    printer('Commands:');
+    for (const command of definition.commands) {
+        const desc = commandArgumentsDescription(command);
+        const commandName = `${command.name} ${desc}`;
+        printer(`  ${padWithSpace(commandName, namePadding)}${command.description}`);
+    }
+};
+
+const printableProgramName = (fullPath: string): string => {
+    const stripExtension = (s: string) => {
+        const indexOfJSExtension = s.lastIndexOf('.js');
+        return indexOfJSExtension === -1
+            ? s
+            : s.slice(0, indexOfJSExtension);
+    };
+    const stripPath = (s: string) => s.slice(s.lastIndexOf('/') + 1);
+    const withoutExtension = stripExtension(fullPath);
+    const withoutPath = stripPath(withoutExtension);
+    return withoutPath;
+};
+
+const isOption = (arg: string): boolean => arg.startsWith('-');
+
+type ErrorHandler = (message: string) => void;
+
+const throwError = (message: string) => { throw new Error(message); };
+const throwOptionError = (name: string) => throwError(`unknown option \`${name}'`);
+const throwOptionMissingParameterError = (name: string) => throwError(`missing parameter to option \`${name}'`);
+const throwCommandError = (name: string) => throwError(`unknown command \`${name}'`);
+const throwCommandMissingParameterError = (name: string) => throwError(`missing parameter to command \`${name}'`);
+
+interface OptionLookup {
+    [name: string]: Option;
+}
+
+interface Context {
+    name: string;
+    args: string[];
+    definition: Definition;
+}
+
+const readArgAndExecute = (context: Context, printer: Printer): Context => {
+    const {args, definition} = context;
+    if (args.length === 0) {
+        return context;
+    }
+
+    const optionLookup: OptionLookup = {};
+    for (const option of definition.options) {
+        for (const name of option.names) {
+            optionLookup[name] = option;
+        }
+    }
+
+    if (isOption(args[0])) {
+        const option = optionLookup[args[0]] || throwOptionError(args[0]);
+        if (option === helpOption) {
+            printUsage(context.name, context.definition, printer);
+            return {
+                ...context,
+                args: [],
+            };
+        }
+        else if (args.length - 1 >= option.args.length) {
+            option.action(...args.slice(1, 1 + option.args.length));
+            return {
+                name: context.name,
+                args: args.slice(1 + option.args.length),
+                definition: context.definition,
+            };
+        }
+        throwOptionMissingParameterError(args[0]);
+    } else {
+        for (const command of definition.commands) {
+            if (command.name === args[0]) {
+                if (isAction(command.actionOrDefinition)) {
+                    const commandArgs = [...args.slice(1, 1 + command.args.length)];
+                    if (commandArgs.length < command.args.length) {
+                        throwCommandMissingParameterError(command.name);
+                    }
+                    command.actionOrDefinition(...commandArgs);
+                    return {
+                        name: command.name,
+                        args: args.slice(1 + command.args.length),
+                        definition: context.definition,
+                    };
+                } else {
+                    return {
+                        name: command.name,
+                        args: args.slice(1),
+                        definition: command.actionOrDefinition,
+                    };
+                }
+            }
+        }
+        throwCommandError(args[0]);
+    }
+    // control never reaches here, because we throw errors, however they are
+    // wrapped in functions so the compiler doesn't recognize them
+    return context;
+};
+
+// tslint:disable-next-line:no-console
+const output = console.log;
+
+export const parseArguments = (
+    args: string[],
+    definition: Definition,
+    printer: Printer = output,
+    errorHandler: ErrorHandler = throwError,
+) => {
+    const name = printableProgramName(args[1]);
+    if (args.length === 2) {
+        printUsage(name, definition, printer);
+        return;
+    }
+
+    try {
+        let context = {
+            name,
+            args: args.slice(2),
+            definition,
+        };
+
+        while (context.args.length > 0) {
+            context = readArgAndExecute(context, printer);
+        }
+    } catch (e) {
+        errorHandler(e.message);
+        return;
+    }
+};

--- a/test/cliParserTest.ts
+++ b/test/cliParserTest.ts
@@ -77,6 +77,44 @@ test('option with parameter', () => {
     expect(optionActionArgValue).toEqual(optionArgValue);
 });
 
+test('option with short alternative and parameter', () => {
+    let optionActionCalled = false;
+    let optionActionArgValue;
+
+    const shortOption = '-q';
+    const longOption = '--quiet';
+    const optionDef = `${shortOption}, ${longOption} <arg>`;
+    const optionArgValue = 'hello';
+    const definition = addOption(optionDef, '', (arg) => {
+        optionActionCalled = true;
+        optionActionArgValue = arg;
+    });
+    const args = baseArgs.concat([shortOption, optionArgValue]);
+    parseArguments(args, definition);
+
+    expect(optionActionCalled).toBeTruthy();
+    expect(optionActionArgValue).toEqual(optionArgValue);
+});
+
+test('option with long alternative and parameter', () => {
+    let optionActionCalled = false;
+    let optionActionArgValue;
+
+    const shortOption = '-q';
+    const longOption = '--quiet';
+    const optionDef = `${shortOption}, ${longOption} <arg>`;
+    const optionArgValue = 'hello';
+    const definition = addOption(optionDef, '', (arg) => {
+        optionActionCalled = true;
+        optionActionArgValue = arg;
+    });
+    const args = baseArgs.concat([longOption, optionArgValue]);
+    parseArguments(args, definition);
+
+    expect(optionActionCalled).toBeTruthy();
+    expect(optionActionArgValue).toEqual(optionArgValue);
+});
+
 test('option with parameter without argument should fail', () => {
     const option = '-o';
     const optionDef = `${option} <arg>`;

--- a/test/cliParserTest.ts
+++ b/test/cliParserTest.ts
@@ -1,0 +1,233 @@
+import { addOption, parseArguments, addCommand, emptyDefinition } from '../src/cliParser';
+import { Debug } from '../src/Debug';
+
+const baseArgs = ['', ''];
+
+beforeEach(() => Debug.setDebug(false));
+test('help is always implicitly defined if any option is defined', () => {
+    const helpOption = '-h';
+    const option = '-o';
+    const definition = addOption(option, '', () => {});
+    const args = baseArgs.concat([helpOption]);
+    parseArguments(args, definition, () => {});
+
+    // expect no exception
+});
+
+test('help is always implicitly defined if any command is defined', () => {
+    const helpOption = '-h';
+    const command = 'command';
+    const definition = addCommand(command, '', () => {});
+    const args = baseArgs.concat([helpOption]);
+    parseArguments(args, definition, () => {});
+
+    // expect no exception
+});
+
+test('basic option', () => {
+    let optionActionCalled = false;
+
+    const option = '-o';
+    const definition = addOption(option, '', () => optionActionCalled = true);
+    const args = baseArgs.concat([option]);
+    parseArguments(args, definition);
+
+    expect(optionActionCalled).toBeTruthy();
+});
+
+test('basic option with short alternative', () => {
+    let optionActionCalled = false;
+
+    const shortOption = '-q';
+    const longOption = '--quiet';
+    const option = `${shortOption}, ${longOption}`;
+    const definition = addOption(option, '', () => optionActionCalled = true);
+    const args = baseArgs.concat([shortOption]);
+    parseArguments(args, definition);
+
+    expect(optionActionCalled).toBeTruthy();
+});
+
+test('basic option with long alternative', () => {
+    let optionActionCalled = false;
+
+    const shortOption = '-q';
+    const longOption = '--quiet';
+    const option = `${shortOption}, ${longOption}`;
+    const definition = addOption(option, '', () => optionActionCalled = true);
+    const args = baseArgs.concat([longOption]);
+    parseArguments(args, definition);
+
+    expect(optionActionCalled).toBeTruthy();
+});
+
+test('option with parameter', () => {
+    let optionActionCalled = false;
+    let optionActionArgValue;
+
+    const option = '-o';
+    const optionDef = `${option} <arg>`;
+    const optionArgValue = 'hello';
+    const definition = addOption(optionDef, '', (arg) => {
+        optionActionCalled = true;
+        optionActionArgValue = arg;
+    });
+    const args = baseArgs.concat([option, optionArgValue]);
+    parseArguments(args, definition);
+
+    expect(optionActionCalled).toBeTruthy();
+    expect(optionActionArgValue).toEqual(optionArgValue);
+});
+
+test('option with parameter without argument should fail', () => {
+    const option = '-o';
+    const optionDef = `${option} <arg>`;
+    const definition = addOption(optionDef, '', (arg) => {});
+    const args = baseArgs.concat([option]);
+    const t = () => {
+        parseArguments(args, definition);
+    };
+
+    expect(t).toThrow(`missing parameter to option \`${option}'`);
+});
+
+test('unknown option', () => {
+    const option = '-o';
+    const definition = emptyDefinition;
+    const args = baseArgs.concat([option]);
+
+    const t = () => {
+        parseArguments(args, definition);
+    };
+
+    expect(t).toThrow('unknown option `-o\'');
+});
+
+test('basic command', () => {
+    let commandActionCalled = false;
+
+    const command = 'command';
+    const definition = addCommand(command, '', () => commandActionCalled = true);
+    const args = baseArgs.concat(command);
+    parseArguments(args, definition);
+
+    expect(commandActionCalled).toBeTruthy();
+});
+
+test('command with parameter without argument should fail', () => {
+    Debug.setDebug(true);
+
+    const command = 'command';
+    const commandDef = `${command} <arg>`;
+    const definition = addCommand(commandDef, '', (arg) => {});
+    const args = baseArgs.concat([command]);
+    const t = () => {
+        parseArguments(args, definition);
+    };
+
+    expect(t).toThrow(`missing parameter to command \`${command}'`);
+});
+
+test('command with parameter', () => {
+    let commandActionCalled = false;
+    let commandActionArgValue;
+
+    const command = 'command';
+    const commandDef = `${command} <arg>`;
+    const commandArgValue = 'hello';
+    const definition = addCommand(commandDef, '', (arg) => {
+        commandActionCalled = true;
+        commandActionArgValue = arg;
+    });
+    const args = baseArgs.concat([command, commandArgValue]);
+    parseArguments(args, definition);
+
+    expect(commandActionCalled).toBeTruthy();
+    expect(commandActionArgValue).toEqual(commandArgValue);
+});
+
+test('unknown command', () => {
+    const unknown = 'unknown';
+    const definition = emptyDefinition;
+    const args = baseArgs.concat(unknown);
+
+    const t = () => {
+        parseArguments(args, definition);
+    };
+
+    expect(t).toThrow(`unknown command \`${unknown}'`);
+});
+
+test('basic option and command', () => {
+    let commandActionCalled = false;
+    let optionActionCalled = false;
+
+    const option = '-o';
+    const command = 'command';
+    const definition = addOption(option, '', () => optionActionCalled = true)
+        .addCommand(command, '', () => commandActionCalled = true);
+    const args = baseArgs.concat([option, command]);
+    parseArguments(args, definition);
+
+    expect(optionActionCalled).toBeTruthy();
+    expect(commandActionCalled).toBeTruthy();
+});
+
+test('several commands', () => {
+    let command1ActionCalled = false;
+    let command2ActionCalled = false;
+
+    const command1 = 'command1';
+    const command2 = 'command2';
+    const definition = addCommand(command1, '', () => command1ActionCalled = true)
+        .addCommand(command2, '', () => command2ActionCalled = true);
+    const args = baseArgs.concat([command1]);
+    parseArguments(args, definition);
+
+    expect(command1ActionCalled).toBeTruthy();
+    expect(command2ActionCalled).toBeFalsy();
+});
+
+test('basic subcommand', () => {
+    let subcommandActionCalled = false;
+
+    const command = 'command';
+    const subcommand = 'subcommand';
+    const definition = addCommand(command, '',
+        addCommand(subcommand, '', () => subcommandActionCalled = true)
+    );
+
+    const args = baseArgs.concat([command, subcommand]);
+    parseArguments(args, definition);
+
+    expect(subcommandActionCalled).toBeTruthy();
+});
+
+test('subcommand with option', () => {
+    Debug.setDebug(true);
+
+    let subcommandActionCalled = false;
+    let subcommandOptionActionCalled = false;
+    let subcommandOptionActionArg;
+
+    const command = 'command';
+    const subcommand = 'subcommand';
+    const option = '-o';
+    const optionDef = `${option} <arg>`;
+    const optionArgValue = 'hello';
+    const definition = addCommand(command, '',
+        addOption(optionDef, '', (arg) => {
+            subcommandOptionActionCalled = true;
+            subcommandOptionActionArg = arg;
+        })
+        .
+        addCommand(subcommand, '', () => subcommandActionCalled = true)
+    );
+
+    const args = baseArgs.concat([command, option, optionArgValue, subcommand]);
+    parseArguments(args, definition);
+
+    expect(subcommandActionCalled).toBeTruthy();
+    expect(subcommandOptionActionCalled).toBeTruthy();
+    expect(subcommandOptionActionArg).toEqual(optionArgValue);
+});

--- a/test/cliParserTest.ts
+++ b/test/cliParserTest.ts
@@ -1,9 +1,7 @@
 import { addOption, parseArguments, addCommand, emptyDefinition } from '../src/cliParser';
-import { Debug } from '../src/Debug';
 
 const baseArgs = ['', ''];
 
-beforeEach(() => Debug.setDebug(false));
 test('help is always implicitly defined if any option is defined', () => {
     const helpOption = '-h';
     const option = '-o';
@@ -115,8 +113,6 @@ test('basic command', () => {
 });
 
 test('command with parameter without argument should fail', () => {
-    Debug.setDebug(true);
-
     const command = 'command';
     const commandDef = `${command} <arg>`;
     const definition = addCommand(commandDef, '', (arg) => {});
@@ -204,8 +200,6 @@ test('basic subcommand', () => {
 });
 
 test('subcommand with option', () => {
-    Debug.setDebug(true);
-
     let subcommandActionCalled = false;
     let subcommandOptionActionCalled = false;
     let subcommandOptionActionArg;


### PR DESCRIPTION
I removed `commander-js` although I liked the API originally. It had two major issues:
- It was not compositional, so if you wanted to create sub-commands with it, you had to write it with a switch/case, but then you lost `commander-js`'s support for help and other features.
- You could only check the values of the options after it started running the commands asynchronously. This led to race-conditions even with the very simple use-case we had, namely to turn Debug output off.

I was looking for alternatives and npm has at least 20 command line parsing projects, but most of them are very simple, one-off projects without tests and documentation, and `yargs` seemed too complex to use. I was thinking how hard can it be to write such a thing, so as a weekend project I built it :)
- It is fully compositional, so you can move commands between different levels very easily, with the options attached to it. 
- The interface is fluent and it lets you define options first, then commands but not the other way.
- It generates usage help that is very similar to commander, but it works also for subcommands.
- The whole library is less then 300 lines with no dependencies.
- It has almost the same amout of tests in LoC :)
- I plan to make it a separate npm package that we can use later and it will be good for practicing, because I've never done it before.