### PR TITLE
Feed update favicon

### DIFF
--- a/docs/SocialApi.md
+++ b/docs/SocialApi.md
@@ -24,7 +24,6 @@ export interface PrivateIdentity extends PublicIdentity {
 export interface Author {
     name: string;
     uri: string;
-    faviconUri: string;
     image?: ImageData;
     identity?: PrivateIdentity;
 }

--- a/src/RSSPostManager.ts
+++ b/src/RSSPostManager.ts
@@ -438,7 +438,7 @@ class _RSSPostManager {
     private convertRSSFeedtoPosts(rssFeed: RSSFeed, feedName: string, favicon: string, feedUrl: string): Post[] {
         const links: Set<string> = new Set();
         const uniques: Set<string> = new Set();
-        const strippedFaviconUri = this.stripTrailing(favicon, '/');
+        const strippedFavicon = this.stripTrailing(favicon, '/');
         const posts = rssFeed.items.map(item => {
             const markdown = this.htmlToMarkdown(item.description);
             const [text, markdownImages] = this.extractTextAndImagesFromMarkdown(markdown, '');
@@ -463,7 +463,7 @@ class _RSSPostManager {
                     name: feedName,
                     uri: feedUrl,
                     image: {
-                        uri: strippedFaviconUri,
+                        uri: strippedFavicon,
                     },
                 },
             };

--- a/src/RSSPostManager.ts
+++ b/src/RSSPostManager.ts
@@ -344,9 +344,7 @@ class _RSSPostManager {
                 author: {
                     name: 'Postmodern',
                     uri: '',
-                    faviconUri: '',
                     image: {
-                        uri: '',
                     },
                 },
             };
@@ -464,7 +462,6 @@ class _RSSPostManager {
                 author: {
                     name: feedName,
                     uri: feedUrl,
-                    faviconUri: strippedFaviconUri,
                     image: {
                         uri: strippedFaviconUri,
                     },

--- a/src/actions/Actions.ts
+++ b/src/actions/Actions.ts
@@ -241,7 +241,6 @@ export const AsyncActions = {
                             : {
                                 name: '',
                                 uri: '',
-                                faviconUri: '',
                                 image: {},
                             }
                     ,

--- a/src/actions/Actions.ts
+++ b/src/actions/Actions.ts
@@ -48,7 +48,7 @@ export enum ActionTypes {
     UPDATE_POST_IMAGES = 'UPDATE-POST-IMAGES',
     UPDATE_POST_IS_UPLOADING = 'UPDATE-POST-IS-UPLOADING',
     UPDATE_AUTHOR_NAME = 'UPDATE-AUTHOR-NAME',
-    UPDATE_AUTHOR_PICTURE_PATH = 'UPDATE-AUTHOR-PICTURE-PATH',
+    UPDATE_AUTHOR_IMAGE = 'UPDATE-AUTHOR-IMAGE',
     UPDATE_AUTHOR_IDENTITY = 'UPDATE-AUTHOR-IDENTITY',
     INCREASE_HIGHEST_SEEN_POST_ID = 'INCREASE-HIGHEST-SEEN-POST-ID',
     APP_STATE_RESET = 'APP-STATE-RESET',
@@ -107,8 +107,8 @@ export const Actions = {
         createAction(ActionTypes.REMOVE_DRAFT),
     updateAuthorName: (name: string) =>
         createAction(ActionTypes.UPDATE_AUTHOR_NAME, { name }),
-    updateAuthorPicturePath: (image: ImageData) =>
-        createAction(ActionTypes.UPDATE_AUTHOR_PICTURE_PATH, { image }),
+    updateAuthorImage: (image: ImageData) =>
+        createAction(ActionTypes.UPDATE_AUTHOR_IMAGE, { image }),
     appStateReset: () =>
         createAction(ActionTypes.APP_STATE_RESET),
     changeSettingSaveToCameraRoll: (value: boolean) =>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -108,9 +108,7 @@ const definitions =
 
             output('Posts:');
             const postCommandLog = await storageApi.downloadPostCommandLog();
-            for (const command of postCommandLog.commands) {
-                output(jsonPrettyPrint(command));
-            }
+            output(jsonPrettyPrint(postCommandLog.commands));
         })
     )
 ;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,7 @@ global.FormData = FormData;
 let output = console.log;
 Debug.setDebug(false);
 let swarmGateway = process.env.SWARM_GATEWAY || Swarm.defaultGateway;
+const jsonPrettyPrint = (obj: any) => JSON.stringify(obj, null, 4);
 
 const definitions =
     addOption('-q, --quiet', 'quiet mode', () => output = () => {})
@@ -103,12 +104,12 @@ const definitions =
             const swarmApi = Swarm.makeApi(feedAddress, dummySigner, swarmGateway);
             const storageApi = makeSwarmStorage(swarmApi);
             const recentPostFeed = await storageApi.downloadRecentPostFeed(0);
-            output('Recent post feed', JSON.stringify(recentPostFeed, null, 2));
+            output('Recent post feed', jsonPrettyPrint(recentPostFeed));
 
             output('Posts:');
             const postCommandLog = await storageApi.downloadPostCommandLog();
             for (const command of postCommandLog.commands) {
-                output(JSON.stringify(command, null, 2));
+                output(jsonPrettyPrint(command));
             }
         })
     )

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -181,7 +181,7 @@ const ButtonList = (props: CardProps) => {
 
 const CardTopIcon = (props: { post: Post, modelHelper: ModelHelper }) => {
     if (props.post.author) {
-        const imageUri = props.modelHelper.getAuthorImageUri(props.post.author);
+        const imageUri = props.modelHelper.getImageUri(props.post.author.image);
         return (
             <Avatar imageUri={imageUri} size='large'/>
         );

--- a/src/components/IdentityOnboarding.tsx
+++ b/src/components/IdentityOnboarding.tsx
@@ -27,7 +27,7 @@ export interface StateProps {
 
 export const IdentityOnboarding = (props: DispatchProps & StateProps) => {
     const modelHelper = new ReactNativeModelHelper(props.gatewayAddress);
-    const authorImageUri = modelHelper.getAuthorImageUri(props.author);
+    const authorImageUri = modelHelper.getImageUri(props.author.image);
     Debug.log('IdentityOnboarding: ', authorImageUri);
     return (
         <KeyboardAvoidingView style={styles.mainContainer}>

--- a/src/components/IdentitySettings.tsx
+++ b/src/components/IdentitySettings.tsx
@@ -77,7 +77,7 @@ const showShareDialog = async (feed?: Feed) => {
 export const IdentitySettings = (props: DispatchProps & StateProps) => {
     const qrCodeValue = generateQRCodeValue(props.ownFeed);
     const modelHelper = new ReactNativeModelHelper(props.gatewayAddress);
-    const authorImageUri = modelHelper.getAuthorImageUri(props.author);
+    const authorImageUri = modelHelper.getImageUri(props.author.image);
     Debug.log('IdentitySettings: ', authorImageUri);
     return (
         <SafeAreaView style={styles.safeAreaContainer}>

--- a/src/containers/IdentitySettingsContainer.ts
+++ b/src/containers/IdentitySettingsContainer.ts
@@ -22,7 +22,7 @@ const mapDispatchToProps = (dispatch: any): DispatchProps => {
             dispatch(Actions.updateAuthorName(text));
         },
         onUpdatePicture: (image: ImageData) => {
-            dispatch(Actions.updateAuthorPicturePath(image));
+            dispatch(Actions.updateAuthorImage(image));
         },
     };
 };

--- a/src/containers/WelcomeContainer.ts
+++ b/src/containers/WelcomeContainer.ts
@@ -19,7 +19,7 @@ const mapDispatchToProps = (dispatch: any): DispatchProps => {
         onCreateUser: async (name: string, image: ImageData, navigation: any) => {
             await dispatch(AsyncActions.chainActions([
                 Actions.updateAuthorName(name),
-                Actions.updateAuthorPicturePath(image),
+                Actions.updateAuthorImage(image),
                 AsyncActions.createUserIdentity(),
                 AsyncActions.createOwnFeed(),
             ]));

--- a/src/models/Author.ts
+++ b/src/models/Author.ts
@@ -6,7 +6,6 @@ export const DEFAULT_AUTHOR_NAME = 'Space Cowboy';
 export interface Author {
     name: string;
     uri: string;
-    faviconUri: string;
     image: ImageData;
     identity?: PrivateIdentity;
 }

--- a/src/models/ModelHelper.ts
+++ b/src/models/ModelHelper.ts
@@ -1,4 +1,3 @@
-import { Author } from './Author';
 import { ImageData } from './ImageData';
 
 export interface Rectangle {
@@ -7,7 +6,6 @@ export interface Rectangle {
 }
 
 export interface ModelHelper {
-    getAuthorImageUri: (author: Author) => string;
     getLocalPath: (localPath: string) => string;
     getImageUri: (image: ImageData) => string;
 }

--- a/src/models/ReactNativeModelHelper.ts
+++ b/src/models/ReactNativeModelHelper.ts
@@ -2,27 +2,11 @@
 import * as RNFS from 'react-native-fs';
 
 import { ModelHelper } from './ModelHelper';
-import { Author } from './Author';
 import { ImageData } from './ImageData';
 import { getSwarmGatewayUrl } from '../swarm/Swarm';
 
 export class ReactNativeModelHelper implements ModelHelper {
     public constructor(private readonly gatewayAddress: string) {
-    }
-
-    public getAuthorImageUri(author: Author): string {
-        // this is here for compatibility with previous version where
-        // image was optional
-        if (author.image == null) {
-            return author.faviconUri;
-        }
-        if (author.image.localPath != null) {
-            return this.getLocalPath(author.image.localPath);
-        }
-        if (author.image.uri != null) {
-            return author.image.uri;
-        }
-        return author.faviconUri;
     }
 
     public getLocalPath(localPath: string): string {

--- a/src/models/__mocks__/ReactNativeModelHelper.ts
+++ b/src/models/__mocks__/ReactNativeModelHelper.ts
@@ -1,12 +1,7 @@
-import { Author } from '../Author';
 import { ModelHelper } from '../ModelHelper';
 import { ImageData } from '../ImageData';
 
 export class ReactNativeModelHelper implements ModelHelper {
-    public getAuthorImageUri(author: Author): string {
-        return 'mock author';
-    }
-
     public getLocalPath(localPath: string): string {
         return `mockpath__${localPath}`;
     }

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -53,7 +53,6 @@ const defaultSettings: Settings = {
 export const defaultAuthor: Author = {
     name: DEFAULT_AUTHOR_NAME,
     uri: '',
-    faviconUri: '',
     image: {
         uri: '',
     },
@@ -61,7 +60,6 @@ export const defaultAuthor: Author = {
 };
 
 const onboardingAuthor: Author = {
-    faviconUri: '',
     name: 'Felfele Assistant',
     uri: '',
     image: {},
@@ -312,7 +310,6 @@ const authorReducer = (author = defaultAuthor, action: Actions): Author => {
         case 'UPDATE-AUTHOR-PICTURE-PATH': {
             return {
                 ...author,
-                faviconUri: action.payload.image.localPath != null ? action.payload.image.localPath : '',
                 image: action.payload.image,
             };
         }

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -307,7 +307,7 @@ const authorReducer = (author = defaultAuthor, action: Actions): Author => {
                 name: action.payload.name,
             };
         }
-        case 'UPDATE-AUTHOR-PICTURE-PATH': {
+        case 'UPDATE-AUTHOR-IMAGE': {
             return {
                 ...author,
                 image: action.payload.image,

--- a/src/swarm-social/swarmStorage.ts
+++ b/src/swarm-social/swarmStorage.ts
@@ -252,7 +252,6 @@ const uploadAuthor = async (
     const uploadedImage = await uploadImage(swarm, author.image!, imageResizer, getLocalPath);
     return {
         ...author,
-        faviconUri: '',
         image: uploadedImage,
         identity: undefined,
     };
@@ -352,7 +351,6 @@ export const downloadRecentPostFeed = async (swarm: Swarm.ReadableApi, url: stri
         const author: Author = {
             name: postFeed.name,
             uri: postFeed.url,
-            faviconUri: authorImage.uri,
             image: authorImage,
         };
         const postFeedWithGatewayImageLinks = {

--- a/src/swarm/Swarm.ts
+++ b/src/swarm/Swarm.ts
@@ -7,7 +7,9 @@ import { safeFetch, safeFetchWithTimeout } from '../Network';
 import { hexToByteArray, byteArrayToHex, stringToByteArray } from '../conversion';
 import { Buffer } from 'buffer';
 
-export const defaultGateway = 'https://swarm-gateways.net';
+// TODO if this changes we have to add either a migration or a setup code to reducers
+// to update it for existing users
+export const defaultGateway = 'https://swarm.felfele.com';
 export const defaultUrlScheme = '/bzz-raw:/';
 export const defaultPrefix = 'bzz://';
 export const defaultFeedPrefix = 'bzz-feed:/';

--- a/test/components/CardTest.tsx
+++ b/test/components/CardTest.tsx
@@ -14,7 +14,6 @@ jest.mock('../../src/ui/misc/Carousel');
 
 describe('card test', () => {
     const testAuthor: Author = {
-        faviconUri: '',
         name: 'Test Elek',
         uri: '',
         image: {},


### PR DESCRIPTION
Supposed to fix #208, however as I started working on this I found lot of tech debt already:
https://github.com/felfele/felfele/issues/208#issuecomment-473972237

The original issue is that somehow the code that invokes the upload of the `Author` was removed, so we don't have a bzz link to the image and therefore everything is filled out with empty strings.

So far I started with removing `faviconUri` from `Author`, because this was legacy code, but we had to take it into account everywhere.

Maybe this will also touch topics described here, because there is already an overlap:
https://github.com/felfele/felfele/issues/181

