### PR TITLE
Fixed feed deletion, refactored NavigationHeader, fixes #231

### DIFF
--- a/src/components/AllFeedScreen.tsx
+++ b/src/components/AllFeedScreen.tsx
@@ -37,14 +37,14 @@ export class AllFeedScreen extends React.Component<Props> {
                 {{
                     navigationHeader: <NavigationHeader
                                     title='All feeds'
-                                    rightButtonText1={
-                                        <Icon
+                                    rightButton1={{
+                                        onPress: () => this.props.navigation.navigate('FeedListViewerContainer'),
+                                        label: <Icon
                                             name={'view-grid'}
                                             size={20}
                                             color={Colors.DARK_GRAY}
-                                        />
-                                    }
-                                    onPressRightButton1={() => this.props.navigation.navigate('FeedListViewerContainer')}
+                                        />,
+                                    }}
                                     onPressTitle={this.ref && this.ref.scrollToTop}
                                 />,
                     listHeader: <FeedHeader

--- a/src/components/Backup.tsx
+++ b/src/components/Backup.tsx
@@ -37,7 +37,7 @@ export class Backup extends React.PureComponent<Props, State> {
         <SafeAreaView style={styles.mainContainer}>
             <NavigationHeader
                 title='Backup'
-                onPressLeftButton={() => this.props.navigation.goBack(null)}
+                navigation={this.props.navigation}
             />
             <View style={styles.secretContainer}>
                 <SimpleTextInput

--- a/src/components/BackupRestore.tsx
+++ b/src/components/BackupRestore.tsx
@@ -23,7 +23,7 @@ export const BackupRestore = (props: Props) => (
     <SafeAreaView style={styles.mainContainer}>
         <NavigationHeader
             title='Backup & Restore'
-            onPressLeftButton={() => props.navigation.goBack(null)}
+            navigation={props.navigation}
         />
         <View style={styles.buttonContainer}>
             <Button text='Backup' onPress={() => props.navigation.navigate('Backup')} />

--- a/src/components/BugReportView.tsx
+++ b/src/components/BugReportView.tsx
@@ -61,22 +61,22 @@ const getBugReportBody = (): string => {
     return bugReportBody;
 };
 
+const onPressSend = () =>
+    Linking.openURL(`mailto:${BUG_REPORT_EMAIL_ADDRESS}?subject=bugReport&body=${getBugReportBody()}`);
+
 export const BugReportView = (props: { navigation?: any, errorView: boolean }) => {
     return (
         <SafeAreaView style={styles.mainContainer}>
             <NavigationHeader
-                leftButtonText={props.navigation ? undefined : ''}
-                onPressLeftButton={() => props.navigation.goBack(null)}
+                navigation={props.navigation}
                 title='Bug Report'
-                rightButtonText1={
-                    <Icon
+                rightButton1={{
+                    onPress: onPressSend,
+                    label: <Icon
                         name={'send'}
                         size={20}
                         color={Colors.BRAND_PURPLE}
-                    />
-                }
-                onPressRightButton1={() => {
-                    Linking.openURL(`mailto:${BUG_REPORT_EMAIL_ADDRESS}?subject=bugReport&body=${getBugReportBody()}`);
+                    />,
                 }}
             />
             <View style={styles.contentContainer}>

--- a/src/components/DebugScreen.tsx
+++ b/src/components/DebugScreen.tsx
@@ -55,7 +55,7 @@ const MaterialCommunityIcon = (props: IconProps) => (
 export const DebugScreen = (props: Props) => (
     <SafeAreaView style={{ backgroundColor: '#EFEFF4', flex: 1 }}>
         <NavigationHeader
-            onPressLeftButton={() => props.navigation.goBack(null)}
+            navigation={props.navigation}
             title='Debug menu'
         />
         <View style={{ backgroundColor: '#EFEFF4', flex: 1 }}>
@@ -149,6 +149,7 @@ const onCreateIdentity = async (props: Props) => {
 
 const onGenerateNewIdentity = async (props: Props) => {
     const privateIdentity = await Swarm.generateSecureIdentity(generateSecureRandom);
+    // tslint:disable-next-line:no-console
     console.log(privateIdentity);
 };
 

--- a/src/components/EditFilter.tsx
+++ b/src/components/EditFilter.tsx
@@ -91,9 +91,11 @@ export class EditFilter extends React.Component<DispatchProps & StateProps, Edit
             <SafeAreaView style={styles.container}>
                 <NavigationHeader
                     title='Edit filter'
-                    onPressLeftButton={() => this.props.navigation.goBack(null)}
-                    rightButtonText1={rightButtonText}
-                    onPressRightButton1={rightButtonAction}
+                    navigation={this.props.navigation}
+                    rightButton1={{
+                        onPress: rightButtonAction,
+                        label: rightButtonText,
+                    }}
                 />
                 <SimpleTextInput
                     defaultValue={this.state.filterText}

--- a/src/components/FavoritesFeedView.tsx
+++ b/src/components/FavoritesFeedView.tsx
@@ -32,17 +32,21 @@ export const FavoritesFeedView = (props: Props) => {
     return (
         <RefreshableFeed modelHelper={modelHelper} {...props}>
             {{
-                navigationHeader: <NavigationHeader
-                                      title='Favorites'
-                                      rightButtonText1={
-                                          <Icon
-                                              name={'view-grid'}
-                                              size={20}
-                                              color={Colors.DARK_GRAY}
-                                          />
-                                      }
-                                      onPressRightButton1={() => props.navigation.navigate('FeedListViewerContainer', { feeds: props.feeds })}
-                                  />,
+                navigationHeader:
+                    <NavigationHeader
+                        title='Favorites'
+                        rightButton1={{
+                            onPress: () => props.navigation.navigate(
+                                'FeedListViewerContainer',
+                                { feeds: props.feeds }
+                            ),
+                            label: <Icon
+                                name={'view-grid'}
+                                size={20}
+                                color={Colors.DARK_GRAY}
+                            />,
+                        }}
+                    />,
                 placeholder: <PlaceholderCard
                                  boldText={PLACEHOLDER_TEXT_1}
                                  regularText={PLACEHOLDER_TEXT_2}

--- a/src/components/FeedInfo.tsx
+++ b/src/components/FeedInfo.tsx
@@ -108,51 +108,36 @@ export class FeedInfo extends React.Component<Props, FeedInfoState> {
     public render() {
         const isExistingFeed = this.props.feed.feedUrl.length > 0;
         const isFollowed = this.props.feed.followed;
-        const rightButtonText1 = this.state.loading
-            ? undefined
-            : <Icon
-                  name={isExistingFeed
-                    ? isFollowed
-                        ? 'link-variant-off'
-                        : 'delete'
-                    : 'download'}
-                  size={20}
-                  color={Colors.DARK_GRAY}
-              />
-        ;
-        const rightButtonAction1 = this.state.loading
-            ? undefined
-            : isExistingFeed
-                ? isFollowed
-                    ? this.onUnfollowFeed
-                    : () => this.onDelete()
-                : async () => await this.fetchFeed()
+
+        const icon = (name: string) => <Icon name={name} size={20} color={Colors.DARK_GRAY} />;
+        const button = (iconName: string, onPress: () => void) => ({
+            label: icon(iconName),
+            onPress,
+        });
+
+        const rightButton1 = isExistingFeed
+            ? isFollowed
+                ? button('link-variant-off', this.onUnfollowFeed)
+                : button('delete', this.onDelete)
+            : button('download', async () => await this.fetchFeed())
         ;
 
-        const rightButtonText2 = this.state.loading || !isExistingFeed
+        const rightButton2 = this.state.loading || !isExistingFeed
             ? undefined
-            : <Icon
-                  name={'open-in-new'}
-                  size={20}
-                  color={Colors.DARK_GRAY}
-              />
-        ;
-        const rightButtonAction2 = this.state.loading || !isExistingFeed
-            ? undefined
-            : () => this.props.navigation.navigate('Feed', { feedUrl: this.props.feed.feedUrl, name: this.props.feed.name })
+            : button('open-in-new', () =>
+                this.props.navigation.navigate('Feed', {
+                    feedUrl: this.props.feed.feedUrl,
+                    name: this.props.feed.name,
+                })
+            )
         ;
         return (
             <SafeAreaView style={styles.container}>
                 <NavigationHeader
-                    onPressLeftButton={() => {
-                        // null is needed otherwise it does not work with switchnavigator backbehavior property
-                        this.props.navigation.goBack(null);
-                    }}
                     title={isExistingFeed ? 'Feed Info' : 'Add Feed'}
-                    rightButtonText1={rightButtonText1}
-                    onPressRightButton1={rightButtonAction1}
-                    rightButtonText2={rightButtonText2}
-                    onPressRightButton2={rightButtonAction2}
+                    rightButton1={rightButton1}
+                    rightButton2={rightButton2}
+                    navigation={this.props.navigation}
                 />
                 <SimpleTextInput
                     defaultValue={this.state.url}

--- a/src/components/FeedListEditor.tsx
+++ b/src/components/FeedListEditor.tsx
@@ -85,12 +85,11 @@ export class FeedListEditor extends React.PureComponent<DispatchProps & StatePro
             <SafeAreaView style={{ backgroundColor: Colors.WHITE, flex: 1 }}>
                 <FeedGrid {...this.props}>
                     <NavigationHeader
-                        onPressLeftButton={() => {
-                            // null is needed otherwise it does not work with switchnavigator backbehavior property
-                            this.props.navigation.goBack(null);
+                        navigation={this.props.navigation}
+                        rightButton1={{
+                            onPress: this.onAddFeed,
+                            label: <MaterialIcon name='add-box' size={24} color={Colors.BUTTON_COLOR} />,
                         }}
-                        rightButtonText1={<MaterialIcon name='add-box' size={24} color={Colors.BUTTON_COLOR} />}
-                        onPressRightButton1={this.onAddFeed}
                         title={this.props.title}
                     />
                 </FeedGrid>

--- a/src/components/FeedView.tsx
+++ b/src/components/FeedView.tsx
@@ -2,18 +2,20 @@ import * as React from 'react';
 import { RefreshableFeed } from './RefreshableFeed';
 import { Feed } from '../models/Feed';
 import { Post } from '../models/Post';
-import { NavigationHeader } from './NavigationHeader';
+import { NavigationHeader, HeaderDefaultLeftButtonIcon } from './NavigationHeader';
 import { Colors } from '../styles';
 
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import * as AreYouSureDialog from './AreYouSureDialog';
 import { ReactNativeModelHelper } from '../models/ReactNativeModelHelper';
+import { FELFELE_ASSISTANT_NAME } from '../reducers';
 
 export interface DispatchProps {
     onRefreshPosts: (feeds: Feed[]) => void;
     onFollowFeed: (feed: Feed) => void;
     onUnfollowFeed: (feed: Feed) => void;
     onToggleFavorite: (feedUrl: string) => void;
+    onRemoveFeed: (feed: Feed) => void;
 }
 
 export interface StateProps {
@@ -33,51 +35,50 @@ export const FeedView = (props: Props) => {
     const isFollowedFeed = props.feeds.find(feed => feed.feedUrl === props.feedUrl && feed.followed === true) != null;
     const modelHelper = new ReactNativeModelHelper(props.gatewayAddress);
     const isLocalFeed = props.isOwnFeed || props.feeds.length === 0;
+    const icon = (name: string, color: string) => <Icon name={name} size={20} color={color} />;
+    const button = (iconName: string, color: string, onPress: () => void) => ({
+        label: icon(iconName, color),
+        onPress,
+    });
+    const toggleFavorite = () => props.onToggleFavorite(props.feedUrl);
+    const navigateToFeedSettings = () => props.navigation.navigate(
+        'FeedSettings',
+        { feed: props.feeds[0] },
+    );
+    const onLinkPressed = async () => onFollowPressed(props.feedUrl,
+        props.feeds,
+        props.onUnfollowFeed,
+        props.onFollowFeed
+    );
+    const rightButton1 = props.isOwnFeed
+        ? props.feedName.length > 0
+            ? button('settings-box', Colors.DARK_GRAY, navigateToFeedSettings)
+            : undefined
+        : isFollowedFeed
+            ? isFavorite(props.feeds, props.feedUrl)
+                ? button('star', Colors.BRAND_PURPLE, toggleFavorite)
+                : button('star', Colors.DARK_GRAY, toggleFavorite)
+            : props.feedName === FELFELE_ASSISTANT_NAME
+                ? undefined
+                : button('delete', Colors.DARK_GRAY, () => removeFeedAndGoBack(props))
+    ;
+    const rightButton2 = isLocalFeed
+        ? undefined
+        : isFollowedFeed
+            ? button('link-variant-off', Colors.DARK_GRAY, onLinkPressed)
+            : button('link-variant', Colors.DARK_GRAY, onLinkPressed)
+    ;
     return (
         <RefreshableFeed modelHelper={modelHelper} {...props}>
             {{
                 navigationHeader: <NavigationHeader
-                    onPressLeftButton={props.onBack}
-                    rightButtonText2={!isLocalFeed ? <Icon
-                        name={isFollowedFeed ? 'link-variant-off' : 'link-variant'}
-                        size={20}
-                        color={Colors.DARK_GRAY}
-                    /> : undefined}
-                    rightButtonText1={!props.isOwnFeed
-                        ? <Icon
-                            name={'star'}
-                            size={20}
-                            color={isFollowedFeed
-                                ? isFavorite(props.feeds, props.feedUrl) ? Colors.BRAND_PURPLE : Colors.DARK_GRAY
-                                : 'transparent'
-                            }
-                        />
-                        : props.feeds.length > 0
-                            ? <Icon
-                                name={'settings-box'}
-                                size={20}
-                                color={Colors.DARK_GRAY}
-                            />
-                            : undefined
-                    }
-                    onPressRightButton2={async () => {
-                        return !props.isOwnFeed && await onFollowPressed(props.feedUrl,
-                            props.feeds,
-                            props.onUnfollowFeed,
-                            props.onFollowFeed);
+                    navigation={props.navigation}
+                    leftButton={{
+                        onPress: props.onBack,
+                        label: HeaderDefaultLeftButtonIcon,
                     }}
-                    onPressRightButton1={() => {
-                        if (props.isOwnFeed) {
-                            if (props.feeds.length > 0) {
-                                props.navigation.navigate('FeedSettings', { feed: props.feeds[0] });
-                            }
-                        } else if (isFollowedFeed) {
-                            props.onToggleFavorite(props.feedUrl);
-                        } else {
-                            props.navigation.navigate('FeedSettings', { feed: props.feeds[0] });
-                        }
-
-                    }}
+                    rightButton1={rightButton1}
+                    rightButton2={rightButton2}
                     title={props.feedName}
                 />,
             }}
@@ -110,5 +111,14 @@ const followFeed = (uri: string, feeds: Feed[], onFollowFeed: (feed: Feed) => vo
     const knownFeed = feeds.find(feed => feed.feedUrl === uri && feed.followed !== true);
     if (knownFeed != null) {
         onFollowFeed(knownFeed);
+    }
+};
+
+const removeFeedAndGoBack = async (props: Props) => {
+    const confirmRemove = await AreYouSureDialog.show('Are you sure you want to delete?');
+    const feedToRemove = props.feeds.find(feed => feed.feedUrl === props.feedUrl && feed.followed !== true);
+    if (feedToRemove != null && confirmRemove) {
+        props.onRemoveFeed(feedToRemove);
+        props.onBack();
     }
 };

--- a/src/components/FilterListEditor.tsx
+++ b/src/components/FilterListEditor.tsx
@@ -22,9 +22,11 @@ export class FilterListEditor extends React.Component<StateProps & DispatchProps
             <SafeAreaView style={styles.container}>
                 <NavigationHeader
                     title='Filters'
-                    onPressLeftButton={() => this.props.navigation.goBack(null)}
-                    rightButtonText1={<MaterialIcon name='add-box' size={24} color={Colors.BUTTON_COLOR} />}
-                    onPressRightButton1={this.onAddFilter}
+                    navigation={this.props.navigation}
+                    rightButton1={{
+                        onPress: this.onAddFilter,
+                        label: <MaterialIcon name='add-box' size={24} color={Colors.BUTTON_COLOR} />,
+                    }}
                 />
                 <ScrollView style={{ backgroundColor: Colors.BACKGROUND_COLOR }}>
                     {this.props.filters.map(filter => (

--- a/src/components/IdentitySettings.tsx
+++ b/src/components/IdentitySettings.tsx
@@ -83,15 +83,18 @@ export const IdentitySettings = (props: DispatchProps & StateProps) => {
         <SafeAreaView style={styles.safeAreaContainer}>
             <KeyboardAvoidingView style={styles.mainContainer}>
                 <NavigationHeader
-                    rightButtonText1={props.ownFeed != null
-                        ? <MaterialCommunityIcon
-                            name={'share'}
-                            size={20}
-                            color={Colors.DARK_GRAY}
-                        />
-                        : undefined
+                    rightButton1={
+                        props.ownFeed != null
+                            ? {
+                                label: <MaterialCommunityIcon
+                                    name={'share'}
+                                    size={20}
+                                    color={Colors.DARK_GRAY}
+                                />,
+                                onPress: async () => showShareDialog(props.ownFeed),
+                            }
+                            : undefined
                     }
-                    onPressRightButton1={async () => showShareDialog(props.ownFeed)}
                     title={SCREEN_TITLE}
                 />
                 <ScrollView

--- a/src/components/LogViewer.tsx
+++ b/src/components/LogViewer.tsx
@@ -40,11 +40,13 @@ export class LogViewer extends React.PureComponent<Props> {
     public render = () => (
         <SafeAreaView style={styles.mainContainer}>
             <NavigationHeader
-                onPressLeftButton={() => this.props.navigation.goBack(null)}
-                rightButtonText1='Clear'
-                onPressRightButton1={() => {
-                    clearLog();
-                    this.props.onTickTime();
+                navigation={this.props.navigation}
+                rightButton1={{
+                    label: 'Clear',
+                    onPress: () => {
+                        clearLog();
+                        this.props.onTickTime();
+                    },
                 }}
                 title='Log viewer'
             />

--- a/src/components/NavigationHeader.tsx
+++ b/src/components/NavigationHeader.tsx
@@ -11,21 +11,6 @@ interface HeaderButton {
     onPress: () => void;
 }
 
-// export interface StateProps {
-//     leftButtonText?: string | React.ReactNode;
-//     rightButtonText1?: string | React.ReactNode;
-//     rightButtonText2?: string | React.ReactNode;
-//     titleImage?: React.ReactNode;
-//     title?: string;
-// }
-
-// export interface DispatchProps {
-//     onPressLeftButton?: () => void;
-//     onPressRightButton1?: () => void;
-//     onPressRightButton2?: () => void;
-//     onPressTitle?: () => void;
-// }
-
 interface HeaderProps {
     leftButton?: HeaderButton;
     rightButton1?: HeaderButton;

--- a/src/components/NavigationHeader.tsx
+++ b/src/components/NavigationHeader.tsx
@@ -6,36 +6,60 @@ import { Colors, DefaultNavigationBarHeight } from '../styles';
 import { TouchableView, TouchableViewDefaultHitSlop } from './TouchableView';
 import { MediumText, RegularText } from '../ui/misc/text';
 
-export interface StateProps {
-    leftButtonText?: string | React.ReactNode;
-    rightButtonText1?: string | React.ReactNode;
-    rightButtonText2?: string | React.ReactNode;
-    titleImage?: React.ReactNode;
+interface HeaderButton {
+    label: string | React.ReactNode;
+    onPress: () => void;
+}
+
+// export interface StateProps {
+//     leftButtonText?: string | React.ReactNode;
+//     rightButtonText1?: string | React.ReactNode;
+//     rightButtonText2?: string | React.ReactNode;
+//     titleImage?: React.ReactNode;
+//     title?: string;
+// }
+
+// export interface DispatchProps {
+//     onPressLeftButton?: () => void;
+//     onPressRightButton1?: () => void;
+//     onPressRightButton2?: () => void;
+//     onPressTitle?: () => void;
+// }
+
+interface HeaderProps {
+    leftButton?: HeaderButton;
+    rightButton1?: HeaderButton;
+    rightButton2?: HeaderButton;
     title?: string;
-}
-
-export interface DispatchProps {
-    onPressLeftButton?: () => void;
-    onPressRightButton1?: () => void;
-    onPressRightButton2?: () => void;
+    titleImage?: React.ReactNode;
     onPressTitle?: () => void;
+    navigation?: any;
 }
 
-export type Props = StateProps & DispatchProps;
-
-export interface State {
-}
+export type Props = HeaderProps;
 
 const BUTTON_COLOR = Colors.DARK_GRAY;
 
+export const HeaderDefaultLeftButtonIcon = <Icon name={'arrow-left'} color={BUTTON_COLOR} size={24} />;
+
 const Header = (props: Props) => (
     <View style={styles.headerContainer}>
-        <TouchableView onPress={props.onPressLeftButton} style={styles.leftContainer}>
+        <TouchableView onPress={
+                props.leftButton != null
+                    ? props.leftButton.onPress
+                    : props.navigation != null
+                        ? () => props.navigation.goBack(null)
+                        : undefined
+            }
+            style={styles.leftContainer}
+        >
             <RegularText style={styles.headerLeftButtonText}>
                 {
-                    props.leftButtonText != null || props.onPressLeftButton == null
-                    ? props.leftButtonText
-                    : <Icon name={'arrow-left'} color={BUTTON_COLOR} size={24} />
+                    props.leftButton != null
+                        ? props.leftButton.label
+                        : props.navigation != null
+                            ? HeaderDefaultLeftButtonIcon
+                            : undefined
                 }
             </RegularText>
         </TouchableView>
@@ -50,11 +74,11 @@ const Header = (props: Props) => (
             </MediumText>
         </TouchableView>
         <View style={styles.rightContainer}>
-            {props.rightButtonText1 &&
-            <RightButton onPress={props.onPressRightButton1} text={props.rightButtonText1} />}
-            {props.rightButtonText2 &&
+            {props.rightButton1 &&
+                <RightButton onPress={props.rightButton1.onPress} text={props.rightButton1.label} />}
+            {props.rightButton2 &&
                 <View style={{paddingRight: 20}}>
-                    <RightButton onPress={props.onPressRightButton2} text={props.rightButtonText2} />
+                    <RightButton onPress={props.rightButton2.onPress} text={props.rightButton2.label} />
                 </View>
             }
         </View>

--- a/src/components/PostEditor.tsx
+++ b/src/components/PostEditor.tsx
@@ -66,22 +66,22 @@ export class PostEditor extends React.Component<Props, State> {
                     style={styles.container}
                 >
                     <NavigationHeader
-                        leftButtonText={
-                            <Icon
+                        leftButton={{
+                            onPress: this.onCancelConfirmation,
+                            label: <Icon
                                 name={'close'}
                                 size={20}
                                 color={Colors.DARK_GRAY}
-                            />
-                        }
-                        onPressLeftButton={this.onCancelConfirmation}
-                        rightButtonText1={
-                            <Icon
+                            />,
+                        }}
+                        rightButton1={{
+                            onPress: this.onPressSubmit,
+                            label: <Icon
                                 name={'send'}
                                 size={20}
                                 color={Colors.BRAND_PURPLE}
-                            />
-                        }
-                        onPressRightButton1={this.onPressSubmit}
+                            />,
+                        }}
                         titleImage={
                             <Avatar
                                 size='medium'

--- a/src/components/Restore.tsx
+++ b/src/components/Restore.tsx
@@ -43,7 +43,7 @@ export class Restore extends React.PureComponent<Props, State> {
         <SafeAreaView style={styles.mainContainer}>
             <NavigationHeader
                 title='Restore'
-                onPressLeftButton={() => this.props.navigation.goBack(null)}
+                navigation={this.props.navigation}
             />
             <View style={styles.secretContainer}>
                 <SimpleTextInput

--- a/src/components/SwarmSettings.tsx
+++ b/src/components/SwarmSettings.tsx
@@ -30,10 +30,7 @@ export const SwarmSettings = (props: Props) => (
     <SafeAreaView style={styles.mainContainer}>
         <KeyboardAvoidingView style={styles.mainContainer}>
             <NavigationHeader
-                onPressLeftButton={() => {
-                    // null is needed otherwise it does not work with switchnavigator backbehavior property
-                    props.navigation.goBack(null);
-                }}
+                navigation={props.navigation}
                 title={'Swarm settings'}
             />
             <Text style={styles.tooltip}>Swarm gateway address</Text>

--- a/src/components/YourFeedView.tsx
+++ b/src/components/YourFeedView.tsx
@@ -29,7 +29,7 @@ export const YourFeedView = (props: Props) => {
             {{
                 navigationHeader: <NavigationHeader
                                       title='All your posts'
-                                      onPressLeftButton={() => props.navigation.goBack(null)}
+                                      navigation={props.navigation}
                                 />,
                 listHeader: <FeedHeader
                                 navigation={props.navigation}

--- a/src/containers/FeedContainer.ts
+++ b/src/containers/FeedContainer.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { AppState, defaultLocalPosts } from '../reducers';
+import { AppState, defaultLocalPosts, FELFELE_ASSISTANT_NAME } from '../reducers';
 import { StateProps, DispatchProps, FeedView } from '../components/FeedView';
 import { AsyncActions, Actions } from '../actions/Actions';
 import { Feed } from '../models/Feed';
@@ -10,7 +10,7 @@ export const mapStateToProps = (state: AppState, ownProps: { navigation: any }):
     const feedName = ownProps.navigation.state.params.name;
 
     const isOwnFeed = feedName === state.author.name;
-    const isAssistantFeed = feedName === 'Felfele Assistant';
+    const isAssistantFeed = feedName === FELFELE_ASSISTANT_NAME;
     const hasOwnFeed = state.ownFeeds.length > 0;
     const ownFeed = hasOwnFeed ? state.ownFeeds[0] : undefined;
     const selectedFeeds = isOwnFeed
@@ -56,6 +56,9 @@ export const mapDispatchToProps = (dispatch: any): DispatchProps => {
         },
         onToggleFavorite: (feedUrl: string) => {
             dispatch(Actions.toggleFeedFavorite(feedUrl));
+        },
+        onRemoveFeed: (feed: Feed) => {
+            dispatch(Actions.removeFeed(feed));
         },
     };
 };

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -59,8 +59,10 @@ export const defaultAuthor: Author = {
     identity: undefined,
 };
 
+export const FELFELE_ASSISTANT_NAME = 'Felfele Assistant';
+
 const onboardingAuthor: Author = {
-    name: 'Felfele Assistant',
+    name: FELFELE_ASSISTANT_NAME,
     uri: '',
     image: {},
 };

--- a/src/ui/screens/feed-settings/FeedSettingsScreen.tsx
+++ b/src/ui/screens/feed-settings/FeedSettingsScreen.tsx
@@ -35,7 +35,7 @@ export const FeedSettingsScreen = (props: Props) => {
     return (
         <SafeAreaView style={{ backgroundColor: Colors.BACKGROUND_COLOR, flex: 1 }}>
             <NavigationHeader
-                onPressLeftButton={() => props.navigation.goBack()}
+                navigation={props.navigation}
                 title={props.feed.name}
             />
             <ScrollView>


### PR DESCRIPTION
Fixes 231# .

Changes proposed in this pull request:
- Fixed the feed deletion by adding a delete button to unfollowed feeds
- Refactored the NavigationHeader buttons to be represented by one property, therefore setting the label and the action belongs together logically now
- Changed the default behaviour of NavigationHeader: if you pass the navigation property then it has a back button that goes back one step in the navigation step. This can be overridden.

