### PR TITLE
Auto sharing posts

### DIFF
--- a/src/actions/Actions.ts
+++ b/src/actions/Actions.ts
@@ -2,7 +2,8 @@ import { ActionsUnion } from './types';
 import { createAction } from './actionHelpers';
 import { Feed } from '../models/Feed';
 import { ContentFilter } from '../models/ContentFilter';
-import { AppState, getAppStateFromSerialized, migrateAppStateToCurrentVersion } from '../reducers';
+import { getAppStateFromSerialized, migrateAppStateToCurrentVersion } from '../reducers';
+import { AppState } from '../reducers/AppState';
 import { RSSPostManager } from '../RSSPostManager';
 import { Post, PublicPost } from '../models/Post';
 import { Author } from '../models/Author';
@@ -269,6 +270,7 @@ export const AsyncActions = {
                     commands: [],
                 },
                 isSyncing: false,
+                shared: true,
             };
             dispatch(InternalActions.addOwnFeed(ownFeed));
         };

--- a/src/actions/Actions.ts
+++ b/src/actions/Actions.ts
@@ -120,8 +120,8 @@ export const Actions = {
         createAction(ActionTypes.CHANGE_SETTING_SHOW_DEBUG_MENU, { value }),
     changeSettingSwarmGatewayAddress: (value: string) =>
         createAction(ActionTypes.CHANGE_SETTING_SWARM_GATEWAY_ADDRESS, { value }),
-    updateOwnFeed: (feed: Partial<LocalFeed>) =>
-        createAction(ActionTypes.UPDATE_OWN_FEED, { feed }),
+    updateOwnFeed: (partialFeed: Partial<LocalFeed>) =>
+        createAction(ActionTypes.UPDATE_OWN_FEED, { partialFeed }),
 };
 
 export const AsyncActions = {

--- a/src/actions/Actions.ts
+++ b/src/actions/Actions.ts
@@ -120,7 +120,7 @@ export const Actions = {
         createAction(ActionTypes.CHANGE_SETTING_SHOW_DEBUG_MENU, { value }),
     changeSettingSwarmGatewayAddress: (value: string) =>
         createAction(ActionTypes.CHANGE_SETTING_SWARM_GATEWAY_ADDRESS, { value }),
-    updateOwnFeed: (feed: LocalFeed) =>
+    updateOwnFeed: (feed: Partial<LocalFeed>) =>
         createAction(ActionTypes.UPDATE_OWN_FEED, { feed }),
 };
 
@@ -186,6 +186,14 @@ export const AsyncActions = {
             dispatch(InternalActions.addPost(post));
             dispatch(InternalActions.increaseHighestSeenPostId());
             Debug.log('Post saved and synced, ', post._id);
+
+            const ownFeeds = getState().ownFeeds;
+            if (ownFeeds.length > 0) {
+                const localFeed = getState().ownFeeds[0];
+                if (localFeed.autoShare) {
+                    dispatch(AsyncActions.sharePost(post));
+                }
+            }
         };
     },
     removePost: (post: Post): Thunk => {
@@ -270,7 +278,7 @@ export const AsyncActions = {
                     commands: [],
                 },
                 isSyncing: false,
-                shared: true,
+                autoShare: true,
             };
             dispatch(InternalActions.addOwnFeed(ownFeed));
         };

--- a/src/components/Backup.tsx
+++ b/src/components/Backup.tsx
@@ -7,7 +7,8 @@ import { Colors, DefaultNavigationBarHeight } from '../styles';
 import { Button } from './Button';
 import { createBackupFromString } from '../BackupRestore';
 import { DateUtils } from '../DateUtils';
-import { AppState, getSerializedAppState } from '../reducers';
+import { getSerializedAppState } from '../reducers';
+import { AppState } from '../reducers/AppState';
 import { stringToHex } from '../conversion';
 
 export interface StateProps {

--- a/src/components/DebugScreen.tsx
+++ b/src/components/DebugScreen.tsx
@@ -5,7 +5,8 @@ import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityI
 // @ts-ignore
 import { generateSecureRandom } from 'react-native-securerandom';
 
-import { AppState, getSerializedAppState, getAppStateFromSerialized } from '../reducers';
+import { getSerializedAppState, getAppStateFromSerialized } from '../reducers';
+import { AppState } from '../reducers/AppState';
 import { Debug } from '../Debug';
 import { NavigationHeader } from './NavigationHeader';
 import * as AreYouSureDialog from './AreYouSureDialog';

--- a/src/containers/AllFeedContainer.ts
+++ b/src/containers/AllFeedContainer.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { AppState } from '../reducers';
+import { AppState } from '../reducers/AppState';
 import { RSSPostManager } from '../RSSPostManager';
 import { AsyncActions, Actions } from '../actions/Actions';
 import { Feed } from '../models/Feed';

--- a/src/containers/BackupContainer.ts
+++ b/src/containers/BackupContainer.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { AppState } from '../reducers/index';
+import { AppState } from '../reducers/AppState';
 import { StateProps, DispatchProps, Backup } from '../components/Backup';
 
 const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {

--- a/src/containers/CardContainer.ts
+++ b/src/containers/CardContainer.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { AppState } from '../reducers/index';
+import { AppState } from '../reducers/AppState';
 import { StateProps, DispatchProps, MemoizedCard } from '../components/Card';
 import { Post } from '../models/Post';
 import { AsyncActions } from '../actions/Actions';

--- a/src/containers/DebugScreenContainer.ts
+++ b/src/containers/DebugScreenContainer.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { AppState } from '../reducers/index';
+import { AppState } from '../reducers/AppState';
 import { AsyncActions, Actions } from '../actions/Actions';
 import { StateProps, DispatchProps, DebugScreen } from '../components/DebugScreen';
 import { Post } from '../models/Post';

--- a/src/containers/EditFilterContainer.ts
+++ b/src/containers/EditFilterContainer.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { AppState } from '../reducers';
+import { AppState } from '../reducers/AppState';
 import { Actions } from '../actions/Actions';
 import { StateProps, DispatchProps, EditFilter } from '../components/EditFilter';
 import { Feed } from '../models/Feed';

--- a/src/containers/FavoritesContainer.ts
+++ b/src/containers/FavoritesContainer.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { AppState } from '../reducers';
+import { AppState } from '../reducers/AppState';
 import { StateProps, DispatchProps } from '../components/FavoritesFeedView';
 import { AsyncActions } from '../actions/Actions';
 import { Feed } from '../models/Feed';

--- a/src/containers/FeedContainer.ts
+++ b/src/containers/FeedContainer.ts
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
-import { AppState, defaultLocalPosts, FELFELE_ASSISTANT_NAME } from '../reducers';
+import { defaultLocalPosts, FELFELE_ASSISTANT_NAME } from '../reducers';
+import { AppState } from '../reducers/AppState';
 import { StateProps, DispatchProps, FeedView } from '../components/FeedView';
 import { AsyncActions, Actions } from '../actions/Actions';
 import { Feed } from '../models/Feed';

--- a/src/containers/FeedInfoContainer.ts
+++ b/src/containers/FeedInfoContainer.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { AppState } from '../reducers';
+import { AppState } from '../reducers/AppState';
 import { Actions, AsyncActions } from '../actions/Actions';
 import { StateProps, DispatchProps, FeedInfo } from '../components/FeedInfo';
 import { Feed } from '../models/Feed';

--- a/src/containers/FeedListEditorContainer.ts
+++ b/src/containers/FeedListEditorContainer.ts
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 
-import { AppState } from '../reducers';
+import { AppState } from '../reducers/AppState';
 import { StateProps, FeedListEditor, DispatchProps } from '../components/FeedListEditor';
 import { Feed } from '../models/Feed';
 import { getFollowedFeeds, getKnownFeeds } from '../selectors/selectors';

--- a/src/containers/FeedListViewerContainer.ts
+++ b/src/containers/FeedListViewerContainer.ts
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 
-import { AppState } from '../reducers';
+import { AppState } from '../reducers/AppState';
 import { StateProps, DispatchProps, FeedListEditor } from '../components/FeedListEditor';
 import { Feed } from '../models/Feed';
 import { getFollowedFeeds, getKnownFeeds } from '../selectors/selectors';

--- a/src/containers/FilterListEditorContainer.ts
+++ b/src/containers/FilterListEditorContainer.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { AppState } from '../reducers';
+import { AppState } from '../reducers/AppState';
 import { StateProps, DispatchProps, FilterListEditor } from '../components/FilterListEditor';
 import { ContentFilter } from '../models/ContentFilter';
 

--- a/src/containers/IdentitySettingsContainer.ts
+++ b/src/containers/IdentitySettingsContainer.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { AppState } from '../reducers/index';
+import { AppState } from '../reducers/AppState';
 import { Actions } from '../actions/Actions';
 import { StateProps, DispatchProps, IdentitySettings } from '../components/IdentitySettings';
 import { ImageData} from '../models/ImageData';

--- a/src/containers/LoadingScreenContainer.ts
+++ b/src/containers/LoadingScreenContainer.ts
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { StateProps, DispatchProps, LoadingScreen } from '../components/LoadingScreen';
-import { AppState } from '../reducers';
+import { AppState } from '../reducers/AppState';
 
 const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
     return {

--- a/src/containers/LogViewerContainer.ts
+++ b/src/containers/LogViewerContainer.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { AppState } from '../reducers/index';
+import { AppState } from '../reducers/AppState';
 import * as Actions from '../actions/Actions';
 import { StateProps, DispatchProps, LogViewer } from '../components/LogViewer';
 

--- a/src/containers/PostEditorContainer.ts
+++ b/src/containers/PostEditorContainer.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { AppState } from '../reducers';
+import { AppState } from '../reducers/AppState';
 import { AsyncActions, Actions } from '../actions/Actions';
 import { StateProps, DispatchProps, PostEditor } from '../components/PostEditor';
 import { Post } from '../models/Post';

--- a/src/containers/RestoreContainer.ts
+++ b/src/containers/RestoreContainer.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { AppState } from '../reducers/index';
+import { AppState } from '../reducers/AppState';
 import * as Actions from '../actions/Actions';
 import { StateProps, DispatchProps, Restore } from '../components/Restore';
 

--- a/src/containers/SettingsEditorContainer.ts
+++ b/src/containers/SettingsEditorContainer.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { AppState } from '../reducers/index';
+import { AppState } from '../reducers/AppState';
 import { Actions } from '../actions/Actions';
 import { StateProps, DispatchProps, SettingsEditor } from '../components/SettingsEditor';
 

--- a/src/containers/SettingsFeedViewContainer.ts
+++ b/src/containers/SettingsFeedViewContainer.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { AppState } from '../reducers';
+import { AppState } from '../reducers/AppState';
 import { StateProps, FeedView } from '../components/FeedView';
 import { mapStateToProps as defaultStateToProps, mapDispatchToProps } from './FeedContainer';
 

--- a/src/containers/SwarmSettingsContainer.ts
+++ b/src/containers/SwarmSettingsContainer.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { AppState } from '../reducers/index';
+import { AppState } from '../reducers/AppState';
 import { Actions } from '../actions/Actions';
 import { StateProps, DispatchProps, SwarmSettings } from '../components/SwarmSettings';
 

--- a/src/containers/WelcomeContainer.ts
+++ b/src/containers/WelcomeContainer.ts
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { StateProps, DispatchProps, Welcome } from '../components/Welcome';
-import { AppState } from '../reducers';
+import { AppState } from '../reducers/AppState';
 import { AsyncActions, Actions } from '../actions/Actions';
 import { ImageData } from '../models/ImageData';
 

--- a/src/containers/YourFeedContainer.ts
+++ b/src/containers/YourFeedContainer.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { AppState } from '../reducers';
+import { AppState } from '../reducers/AppState';
 import { StateProps, DispatchProps, YourFeedView } from '../components/YourFeedView';
 import { Post } from '../models/Post';
 import { Actions } from '../actions/Actions';

--- a/src/reducers/AppState.ts
+++ b/src/reducers/AppState.ts
@@ -1,0 +1,5 @@
+import { AppStateV2 } from './version2';
+
+export const currentAppStateVersion = 2;
+
+export type AppState = AppStateV2;

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -242,13 +242,13 @@ const ownFeedsReducer = (ownFeeds: LocalFeed[] = [], action: Actions): LocalFeed
             return [...ownFeeds, action.payload.feed];
         }
         case 'UPDATE-OWN-FEED': {
-            const ind = ownFeeds.findIndex(feed => action.payload.feed.feedUrl === feed.feedUrl);
+            const ind = ownFeeds.findIndex(feed => action.payload.partialFeed.feedUrl === feed.feedUrl);
             if (ind === -1) {
                 return ownFeeds;
             }
             return updateArrayItem(ownFeeds, ind, (feed) => ({
                 ...feed,
-                ...action.payload.feed,
+                ...action.payload.partialFeed,
             }));
 
         }

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -9,7 +9,6 @@ import thunkMiddleware from 'redux-thunk';
 import {
     persistStore,
     persistReducer,
-    PersistedState,
     createMigrate,
     getStoredState,
     KEY_PREFIX,
@@ -25,23 +24,11 @@ import { Author, DEFAULT_AUTHOR_NAME } from '../models/Author';
 import { Metadata } from '../models/Metadata';
 import { Debug } from '../Debug';
 import { LocalFeed } from '../social/api';
-import { migrateAppState, currentAppStateVersion } from './migration';
+import { migrateAppState } from './migration';
 import { immutableTransformHack } from './immutableTransformHack';
 import { removeFromArray, updateArrayItem, insertInArray } from '../helpers/immutable';
 import * as Swarm from '../swarm/Swarm';
-
-export interface AppState extends PersistedState {
-    contentFilters: ContentFilter[];
-    feeds: Feed[];
-    ownFeeds: LocalFeed[];
-    settings: Settings;
-    author: Author;
-    currentTimestamp: number;
-    rssPosts: Post[];
-    localPosts: Post[];
-    draft: Post | null;
-    metadata: Metadata;
-}
+import { AppState, currentAppStateVersion } from './AppState';
 
 const defaultSettings: Settings = {
     saveToCameraRoll: true,

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -242,7 +242,7 @@ const ownFeedsReducer = (ownFeeds: LocalFeed[] = [], action: Actions): LocalFeed
             return [...ownFeeds, action.payload.feed];
         }
         case 'UPDATE-OWN-FEED': {
-            const ind = ownFeeds.findIndex(feed => feed != null && action.payload.feed.feedUrl === feed.feedUrl);
+            const ind = ownFeeds.findIndex(feed => action.payload.feed.feedUrl === feed.feedUrl);
             if (ind === -1) {
                 return ownFeeds;
             }
@@ -399,7 +399,6 @@ const metadataReducer = (metadata: Metadata = defaultMetadata, action: Actions):
 };
 
 const appStateReducer = (state: AppState = defaultState, action: Actions): AppState => {
-    Debug.log('appStateReducer', 'action', action);
     switch (action.type) {
         case 'APP-STATE-RESET': {
             Debug.log('App state reset');
@@ -411,7 +410,12 @@ const appStateReducer = (state: AppState = defaultState, action: Actions): AppSt
         }
         default: {
             try {
-                return combinedReducers(state, action);
+                const newState = combinedReducers(state, action);
+                if (action.type !== 'TIME-TICK') {
+                    // tslint:disable-next-line:no-console
+                    console.log('appStateReducer', 'action', action, 'newState', newState);
+                }
+                return newState;
             } catch (e) {
                 Debug.log('reducer error: ', e);
                 return state;

--- a/src/reducers/migration.ts
+++ b/src/reducers/migration.ts
@@ -1,77 +1,10 @@
-import { MigrationManifest, PersistedState } from 'redux-persist';
-import { Debug } from '../Debug';
-import { AppState } from '.';
-import { RecentPostFeed, shareNewPost } from '../social/api';
-import { ContentFilter } from '../models/ContentFilter';
-import { Feed } from '../models/Feed';
-import { PublicPost, Post } from '../models/Post';
-import { Author } from '../models/Author';
-import { Metadata } from '../models/Metadata';
-import { PostCommandLog, emptyPostCommandLog } from '../social/api';
-import * as Swarm from '../swarm/Swarm';
-
-export const currentAppStateVersion = 1;
-
-const migrateUnversionedToVersion0 = (state: PersistedState): AppState => {
-    Debug.log('Migrate unversioned to version 0');
-    const appState = state as AppState;
-    const version0AppState = {
-        ...appState,
-        feeds: appState.feeds.map(feed => ({
-            ...feed,
-            followed: true,
-        })),
-    };
-    return version0AppState;
-};
-
-export interface SettingsV0 {
-    saveToCameraRoll: boolean;
-    showSquareImages: boolean;
-    showDebugMenu: boolean;
-}
-
-export interface AppStateV0 extends PersistedState {
-    contentFilters: ContentFilter[];
-    feeds: Feed[];
-    ownFeeds: RecentPostFeed[];
-    settings: SettingsV0;
-    author: Author;
-    currentTimestamp: number;
-    rssPosts: Post[];
-    localPosts: Post[];
-    draft: Post | null;
-    metadata: Metadata;
-    postUploadQueue: Post[];
-}
-
-const makePostCommandLogFromPosts = (posts: PublicPost[]): PostCommandLog => {
-    return posts.reduceRight<PostCommandLog>(
-        (log, post) => shareNewPost(post, '', log),
-        emptyPostCommandLog,
-    );
-};
-
-const migrateVersion0ToVersion1 = (state: PersistedState): AppState => {
-    Debug.log('Migrate unversioned to version 0');
-    const appStateV0 = state as AppStateV0;
-    const version1AppState = {
-        ...appStateV0,
-        ownFeeds: appStateV0.ownFeeds.map(ownFeed => ({
-            ...ownFeed,
-            isSyncing: false,
-            postCommandLog: makePostCommandLogFromPosts(ownFeed.posts),
-        })),
-        settings: {
-            ...appStateV0.settings,
-            swarmGatewayAddress: Swarm.defaultGateway,
-        },
-        postUploadQueue: undefined,
-    };
-    return version1AppState;
-};
+import { MigrationManifest } from 'redux-persist';
+import { migrateUnversionedToVersion0 } from './version0';
+import { migrateVersion0ToVersion1 } from './version1';
+import { migrateVersion1ToVersion2 } from './version2';
 
 export const migrateAppState: MigrationManifest = {
     0: migrateUnversionedToVersion0,
     1: migrateVersion0ToVersion1,
+    currentAppStateVersion: migrateVersion1ToVersion2,
 };

--- a/src/reducers/version0.ts
+++ b/src/reducers/version0.ts
@@ -1,0 +1,42 @@
+import { PersistedState } from 'redux-persist';
+import { Debug } from '../Debug';
+import { RecentPostFeed } from '../social/api';
+import { ContentFilter } from '../models/ContentFilter';
+import { Feed } from '../models/Feed';
+import { Post } from '../models/Post';
+import { Author } from '../models/Author';
+import { Metadata } from '../models/Metadata';
+
+interface SettingsV0 {
+    saveToCameraRoll: boolean;
+    showSquareImages: boolean;
+    showDebugMenu: boolean;
+}
+
+export interface AppStateV0 extends PersistedState {
+    contentFilters: ContentFilter[];
+    feeds: Feed[];
+    ownFeeds: RecentPostFeed[];
+    settings: SettingsV0;
+    author: Author;
+    currentTimestamp: number;
+    rssPosts: Post[];
+    localPosts: Post[];
+    draft: Post | null;
+    metadata: Metadata;
+    postUploadQueue: Post[];
+}
+
+export const migrateUnversionedToVersion0 = (state: PersistedState): AppStateV0 => {
+    Debug.log('Migrate unversioned to version 0');
+    const appState = state as any;
+    const version0AppState = {
+        ...appState,
+        feeds: appState.feeds.map((feed: Feed) => ({
+            ...feed,
+            followed: true,
+        })),
+        postUploadQueue: [],
+    };
+    return version0AppState;
+};

--- a/src/reducers/version1.ts
+++ b/src/reducers/version1.ts
@@ -1,0 +1,60 @@
+import { PersistedState } from 'redux-persist';
+import { Debug } from '../Debug';
+import {
+    RecentPostFeed,
+    PostCommandLog,
+    shareNewPost,
+    emptyPostCommandLog,
+} from '../social/api';
+import { ContentFilter } from '../models/ContentFilter';
+import { Feed } from '../models/Feed';
+import { Post, PublicPost } from '../models/Post';
+import { Author } from '../models/Author';
+import { Metadata } from '../models/Metadata';
+import { Settings } from '../models/Settings';
+import * as Swarm from '../swarm/Swarm';
+import { AppStateV0 } from './version0';
+
+const makePostCommandLogFromPosts = (posts: PublicPost[]): PostCommandLog => {
+    return posts.reduceRight<PostCommandLog>(
+        (log, post) => shareNewPost(post, '', log),
+        emptyPostCommandLog,
+    );
+};
+
+interface LocalFeedV1 extends RecentPostFeed {
+    postCommandLog: PostCommandLog;
+    isSyncing: boolean;
+}
+
+export interface AppStateV1 extends PersistedState {
+    contentFilters: ContentFilter[];
+    feeds: Feed[];
+    ownFeeds: LocalFeedV1[];
+    settings: Settings;
+    author: Author;
+    currentTimestamp: number;
+    rssPosts: Post[];
+    localPosts: Post[];
+    draft: Post | null;
+    metadata: Metadata;
+}
+
+export const migrateVersion0ToVersion1 = (state: PersistedState): AppStateV1 => {
+    Debug.log('Migrate version 0 to version 1');
+    const appStateV0 = state as AppStateV0;
+    const version1AppState = {
+        ...appStateV0,
+        ownFeeds: appStateV0.ownFeeds.map(ownFeed => ({
+            ...ownFeed,
+            isSyncing: false,
+            postCommandLog: makePostCommandLogFromPosts(ownFeed.posts),
+        })),
+        settings: {
+            ...appStateV0.settings,
+            swarmGatewayAddress: Swarm.defaultGateway,
+        },
+        postUploadQueue: undefined,
+    };
+    return version1AppState;
+};

--- a/src/reducers/version2.ts
+++ b/src/reducers/version2.ts
@@ -27,7 +27,10 @@ export const migrateVersion1ToVersion2 = (state: PersistedState): AppStateV2 => 
     const appStateV1 = state as AppStateV1;
     const appStateV2 = {
         ...appStateV1,
-        ownFeeds: appStateV1.ownFeeds.map(localFeed => ({...localFeed, shared: false})),
+        ownFeeds: appStateV1.ownFeeds.map(localFeed => ({
+            ...localFeed,
+            autoShare: false,
+        })),
     };
     return appStateV2;
 };

--- a/src/reducers/version2.ts
+++ b/src/reducers/version2.ts
@@ -1,0 +1,33 @@
+import { PersistedState } from 'redux-persist';
+import { Debug } from '../Debug';
+import { ContentFilter } from '../models/ContentFilter';
+import { Feed } from '../models/Feed';
+import { Post } from '../models/Post';
+import { Author } from '../models/Author';
+import { Metadata } from '../models/Metadata';
+import { Settings } from '../models/Settings';
+import { LocalFeed } from '../social/api';
+import { AppStateV1 } from './version1';
+
+export interface AppStateV2 extends PersistedState {
+    contentFilters: ContentFilter[];
+    feeds: Feed[];
+    ownFeeds: LocalFeed[];
+    settings: Settings;
+    author: Author;
+    currentTimestamp: number;
+    rssPosts: Post[];
+    localPosts: Post[];
+    draft: Post | null;
+    metadata: Metadata;
+}
+
+export const migrateVersion1ToVersion2 = (state: PersistedState): AppStateV2 => {
+    Debug.log('Migrate version 1 to version 2');
+    const appStateV1 = state as AppStateV1;
+    const appStateV2 = {
+        ...appStateV1,
+        ownFeeds: appStateV1.ownFeeds.map(localFeed => ({...localFeed, shared: false})),
+    };
+    return appStateV2;
+};

--- a/src/selectors/selectors.ts
+++ b/src/selectors/selectors.ts
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import { AppState } from '../reducers';
+import { AppState } from '../reducers/AppState';
 import { Post } from '../models/Post';
 import { Feed } from '../models/Feed';
 

--- a/src/social/api.ts
+++ b/src/social/api.ts
@@ -96,6 +96,7 @@ export interface RecentPostFeed extends Feed {
 export interface LocalFeed extends RecentPostFeed {
     postCommandLog: PostCommandLog;
     isSyncing: boolean;
+    shared: boolean;
 }
 
 /**

--- a/src/social/api.ts
+++ b/src/social/api.ts
@@ -96,7 +96,7 @@ export interface RecentPostFeed extends Feed {
 export interface LocalFeed extends RecentPostFeed {
     postCommandLog: PostCommandLog;
     isSyncing: boolean;
-    shared: boolean;
+    autoShare: boolean;
 }
 
 /**

--- a/src/ui/screens/feed-settings/FeedSettingsContainer.ts
+++ b/src/ui/screens/feed-settings/FeedSettingsContainer.ts
@@ -1,13 +1,41 @@
 import { connect } from 'react-redux';
-import { StateProps, FeedSettingsScreen } from './FeedSettingsScreen';
+import { StateProps, DispatchProps, FeedSettingsScreen } from './FeedSettingsScreen';
 import { AppState } from '../../../reducers/AppState';
+import { LocalFeed } from '../../../social/api';
+import { Actions } from '../../../actions/Actions';
+import { emptyPostCommandLog } from '../../../social/api';
+
+const emptyFeed: LocalFeed = {
+    name: '',
+    url: '',
+    feedUrl: '',
+    favicon: '',
+    isSyncing: false,
+    authorImage: {},
+    posts: [],
+    postCommandLog: emptyPostCommandLog,
+    autoShare: false,
+};
 
 const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
+    const paramFeed = ownProps.navigation.state.params.feed;
+    const feed = state.ownFeeds.find(ownFeed => ownFeed.feedUrl === paramFeed.feedUrl) || emptyFeed;
     return {
         navigation: ownProps.navigation,
         settings: state.settings,
-        feed: ownProps.navigation.state.params.feed,
+        feed,
     };
 };
 
-export const FeedSettingsContainer = connect(mapStateToProps)(FeedSettingsScreen);
+const mapDispatchToProps = (dispatch: any): DispatchProps => {
+    return {
+        onChangeFeedSharing: (feed: LocalFeed, shared: boolean) => {
+            dispatch(Actions.updateOwnFeed({
+                feedUrl: feed.feedUrl,
+                autoShare,
+            }));
+        },
+    };
+};
+
+export const FeedSettingsContainer = connect(mapStateToProps, mapDispatchToProps)(FeedSettingsScreen);

--- a/src/ui/screens/feed-settings/FeedSettingsContainer.ts
+++ b/src/ui/screens/feed-settings/FeedSettingsContainer.ts
@@ -29,7 +29,7 @@ const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateP
 
 const mapDispatchToProps = (dispatch: any): DispatchProps => {
     return {
-        onChangeFeedSharing: (feed: LocalFeed, shared: boolean) => {
+        onChangeFeedSharing: (feed: LocalFeed, autoShare: boolean) => {
             dispatch(Actions.updateOwnFeed({
                 feedUrl: feed.feedUrl,
                 autoShare,

--- a/src/ui/screens/feed-settings/FeedSettingsContainer.ts
+++ b/src/ui/screens/feed-settings/FeedSettingsContainer.ts
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { StateProps, FeedSettingsScreen } from './FeedSettingsScreen';
-import { AppState } from '../../../reducers';
+import { AppState } from '../../../reducers/AppState';
 
 const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
     return {

--- a/src/ui/screens/feed-settings/FeedSettingsScreen.tsx
+++ b/src/ui/screens/feed-settings/FeedSettingsScreen.tsx
@@ -12,16 +12,18 @@ import { Colors } from '../../../styles';
 import { NavigationHeader } from '../../../components/NavigationHeader';
 import { RowItem } from '../../../ui/misc/RowButton';
 import { ReactNativeModelHelper } from '../../../models/ReactNativeModelHelper';
-import { RecentPostFeed } from '../../../social/api';
+import { LocalFeed } from '../../../social/api';
 import { TabBarPlaceholder } from '../../misc/TabBarPlaceholder';
 
 export interface StateProps {
     navigation: any;
     settings: Settings;
-    feed: RecentPostFeed;
+    feed: LocalFeed;
 }
 
-export interface DispatchProps { }
+export interface DispatchProps {
+    onChangeFeedSharing: (feed: LocalFeed, value: boolean) => void;
+}
 
 type Props = StateProps & DispatchProps;
 
@@ -56,6 +58,12 @@ export const FeedSettingsScreen = (props: Props) => {
                     switchState={true}
                     buttonStyle='switch'
                     switchDisabled={true}
+                />
+                <RowItem
+                    title='Automatic sharing'
+                    switchState={props.feed.autoShare}
+                    buttonStyle='switch'
+                    onSwitchValueChange={(value) => props.onChangeFeedSharing(props.feed, value)}
                 />
                 <Text style={styles.explanation}>{ASSOCIATED_EXPLANATION}</Text>
                 <Text style={styles.label}>{PRIVACY_SHARING_LABEL}</Text>


### PR DESCRIPTION
Fixes #222 .

Changes proposed in this pull request:
- There is a new flag called `autoShare` in LocalFeed, if that's turned on then creating a new post will automatically shared too
- By default this is turned on, except for migrated users to keep previous behavior
