### PR TITLE
No any navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -238,7 +238,7 @@ const Root = createBottomTabNavigator(
                     />
                 ),
                 tabBarOnPress: ({ navigation }: { navigation: TypedNavigation }) => {
-                    navigation.navigate<Routes, 'Post'>('Post', {});
+                    navigation.navigate('Post', {});
                 },
             },
         },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import { CategoriesContainer } from './ui/screens/explore/CategoriesContainer';
 import { SubCategoriesContainer } from './ui/screens/explore/SubCategoriesContainer';
 import { NewsSourceGridContainer } from './ui/screens/explore/NewsSourceGridContainer';
 import { NewsSourceFeedContainer } from './containers/NewSourceFeedContainer';
+import { Routes, TypedNavigation } from './helpers/navigation';
 
 YellowBox.ignoreWarnings([
     'Method `jumpToIndex` is deprecated.',
@@ -236,8 +237,8 @@ const Root = createBottomTabNavigator(
                         color={Colors.BRAND_PURPLE}
                     />
                 ),
-                tabBarOnPress: ({ navigation }: NavigationScreenProps) => {
-                    navigation.navigate('Post');
+                tabBarOnPress: ({ navigation }: { navigation: TypedNavigation }) => {
+                    navigation.navigate<Routes, 'Post'>('Post', {});
                 },
             },
         },

--- a/src/actions/Actions.ts
+++ b/src/actions/Actions.ts
@@ -25,6 +25,7 @@ import { generateSecureRandom } from 'react-native-securerandom';
 import { isPostFeedUrl, loadRecentPosts, makeSwarmStorage, makeSwarmStorageSyncer, SwarmHelpers } from '../swarm-social/swarmStorage';
 import { resizeImageIfNeeded, resizeImageForPlaceholder } from '../ImageUtils';
 import { ReactNativeModelHelper } from '../models/ReactNativeModelHelper';
+import { FELFELE_ASSISTANT_URL } from '../reducers/defaultData';
 
 export enum ActionTypes {
     ADD_CONTENT_FILTER = 'ADD-CONTENT-FILTER',
@@ -436,7 +437,7 @@ const mergeImages = (localImages: ImageData[], uploadedImages: ImageData[]): Ima
 };
 
 const loadPostsFromFeeds = async (swarm: Swarm.ReadableApi, feeds: Feed[]): Promise<Post[]> => {
-    const feedsWithoutOnboarding = feeds.filter(feed => feed.feedUrl !== 'local/onboarding');
+    const feedsWithoutOnboarding = feeds.filter(feed => feed.feedUrl !== FELFELE_ASSISTANT_URL);
     const rssFeeds = feedsWithoutOnboarding.filter(feed => !isPostFeedUrl(feed.url));
     const postFeeds = feedsWithoutOnboarding.filter(feed => isPostFeedUrl(feed.url));
     const allPostsCombined = await Promise.all([

--- a/src/components/AllFeedScreen.tsx
+++ b/src/components/AllFeedScreen.tsx
@@ -9,6 +9,7 @@ import { ImageData } from '../models/ImageData';
 import { FeedHeader } from './FeedHeader';
 import { ReactNativeModelHelper } from '../models/ReactNativeModelHelper';
 import SplashScreen from 'react-native-splash-screen';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
 export interface DispatchProps {
     onRefreshPosts: (feeds: Feed[]) => void;
@@ -16,7 +17,7 @@ export interface DispatchProps {
 }
 
 export interface StateProps {
-    navigation: any;
+    navigation: TypedNavigation;
     posts: Post[];
     feeds: Feed[];
     profileImage: ImageData;
@@ -38,7 +39,7 @@ export class AllFeedScreen extends React.Component<Props> {
                     navigationHeader: <NavigationHeader
                                     title='All feeds'
                                     rightButton1={{
-                                        onPress: () => this.props.navigation.navigate('FeedListViewerContainer', {
+                                        onPress: () => this.props.navigation.navigate<Routes, 'FeedListViewerContainer'>('FeedListViewerContainer', {
                                             showExplore: true,
                                         }),
                                         label: <Icon

--- a/src/components/AllFeedScreen.tsx
+++ b/src/components/AllFeedScreen.tsx
@@ -39,7 +39,7 @@ export class AllFeedScreen extends React.Component<Props> {
                     navigationHeader: <NavigationHeader
                                     title='All feeds'
                                     rightButton1={{
-                                        onPress: () => this.props.navigation.navigate<Routes, 'FeedListViewerContainer'>('FeedListViewerContainer', {
+                                        onPress: () => this.props.navigation.navigate('FeedListViewerContainer', {
                                             showExplore: true,
                                         }),
                                         label: <Icon

--- a/src/components/Backup.tsx
+++ b/src/components/Backup.tsx
@@ -10,9 +10,10 @@ import { DateUtils } from '../DateUtils';
 import { getSerializedAppState } from '../reducers';
 import { AppState } from '../reducers/AppState';
 import { stringToHex } from '../conversion';
+import { TypedNavigation } from '../helpers/navigation';
 
 export interface StateProps {
-    navigation: any;
+    navigation: TypedNavigation;
     appState: AppState;
 }
 

--- a/src/components/BackupRestore.tsx
+++ b/src/components/BackupRestore.tsx
@@ -27,8 +27,8 @@ export const BackupRestore = (props: Props) => (
             navigation={props.navigation}
         />
         <View style={styles.buttonContainer}>
-            <Button text='Backup' onPress={() => props.navigation.navigate<Routes, 'Backup'>('Backup', {})} />
-            <Button text='Restore' onPress={() => props.navigation.navigate<Routes, 'Restore'>('Restore', {})} />
+            <Button text='Backup' onPress={() => props.navigation.navigate('Backup', {})} />
+            <Button text='Restore' onPress={() => props.navigation.navigate('Restore', {})} />
         </View>
     </SafeAreaView>
 );

--- a/src/components/BackupRestore.tsx
+++ b/src/components/BackupRestore.tsx
@@ -6,9 +6,10 @@ import {
 } from 'react-native';
 import { NavigationHeader } from './NavigationHeader';
 import { Button } from './Button';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
 export interface StateProps {
-    navigation: any;
+    navigation: TypedNavigation;
 }
 
 export interface DispatchProps {
@@ -26,8 +27,8 @@ export const BackupRestore = (props: Props) => (
             navigation={props.navigation}
         />
         <View style={styles.buttonContainer}>
-            <Button text='Backup' onPress={() => props.navigation.navigate('Backup')} />
-            <Button text='Restore' onPress={() => props.navigation.navigate('Restore')} />
+            <Button text='Backup' onPress={() => props.navigation.navigate<Routes, 'Backup'>('Backup', {})} />
+            <Button text='Restore' onPress={() => props.navigation.navigate<Routes, 'Restore'>('Restore', {})} />
         </View>
     </SafeAreaView>
 );

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -213,7 +213,7 @@ const CardTopOriginalAuthorText = (props: {
         return (
             <TouchableView
                 style={{flexDirection: 'row'}}
-                onPress={() => props.navigation.navigate<Routes, 'Feed'>('Feed', {
+                onPress={() => props.navigation.navigate('Feed', {
                     feedUrl,
                     name,
                 })}
@@ -238,7 +238,7 @@ const CardTop = (props: {
     const url = props.post.link || '';
     const hostnameText = url === '' ? '' : ' -  ' + urlUtils.getHumanHostname(url);
     const onPress = props.post.author
-        ? () => props.navigation.navigate<Routes, 'Feed'>('Feed', {
+        ? () => props.navigation.navigate('Feed', {
             feedUrl: props.post.author!.uri || '',
             name: authorName,
         })

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -2,7 +2,16 @@ import * as React from 'react';
 import { Post, PostReferences } from '../models/Post';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { Colors } from '../styles';
-import { View, ActivityIndicator, TouchableOpacity, TouchableWithoutFeedback, Dimensions, Platform, StyleSheet, Image, Text, Linking, Alert, Share } from 'react-native';
+import {
+    View,
+    ActivityIndicator,
+    TouchableOpacity,
+    Dimensions,
+    Platform,
+    StyleSheet,
+    Linking,
+    Alert,
+} from 'react-native';
 import { TouchableView } from './TouchableView';
 import { DateUtils } from '../DateUtils';
 import * as urlUtils from '../helpers/urlUtils';
@@ -18,6 +27,7 @@ import { CardMarkdown } from './CardMarkdown';
 import { calculateImageDimensions, ModelHelper } from '../models/ModelHelper';
 import { Author } from '../models/Author';
 import { DEFAULT_AUTHOR_NAME } from '../reducers/defaultData';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
 export interface StateProps {
     showSquareImages: boolean;
@@ -27,7 +37,7 @@ export interface StateProps {
     author: Author;
     modelHelper: ModelHelper;
     togglePostSelection: (post: Post) => void;
-    navigate: (view: string, {}) => void;
+    navigation: TypedNavigation;
 }
 
 export interface DispatchProps {
@@ -49,7 +59,7 @@ export const Card = (props: CardProps) => {
                 currentTimestamp={props.currentTimestamp}
                 author={props.author}
                 modelHelper={props.modelHelper}
-                navigate={props.navigate}
+                navigation={props.navigation}
                 onSharePost={props.onSharePost}
             />
             <TouchableOpacity
@@ -193,7 +203,7 @@ const CardTopIcon = (props: { post: Post, modelHelper: ModelHelper }) => {
 
 const CardTopOriginalAuthorText = (props: {
     references: PostReferences | undefined,
-    navigate: (view: string, {}) => void,
+    navigation: TypedNavigation,
 }) => {
     if (props.references == null || props.references.originalAuthor == null) {
         return null;
@@ -203,7 +213,7 @@ const CardTopOriginalAuthorText = (props: {
         return (
             <TouchableView
                 style={{flexDirection: 'row'}}
-                onPress={() => props.navigate('Feed', {
+                onPress={() => props.navigation.navigate<Routes, 'Feed'>('Feed', {
                     feedUrl,
                     name,
                 })}
@@ -219,7 +229,7 @@ const CardTop = (props: {
     currentTimestamp: number,
     author: Author,
     modelHelper: ModelHelper,
-    navigate: (view: string, {}) => void,
+    navigation: TypedNavigation,
     onSharePost: (post: Post) => void,
 }) => {
     const postUpdateTime = props.post.updatedAt || props.post.createdAt;
@@ -228,7 +238,7 @@ const CardTop = (props: {
     const url = props.post.link || '';
     const hostnameText = url === '' ? '' : ' -  ' + urlUtils.getHumanHostname(url);
     const onPress = props.post.author
-        ? () => props.navigate('Feed', {
+        ? () => props.navigation.navigate<Routes, 'Feed'>('Feed', {
             feedUrl: props.post.author!.uri || '',
             name: authorName,
         })
@@ -246,7 +256,7 @@ const CardTop = (props: {
                     <MediumText style={styles.username} numberOfLines={1}>{authorName}</MediumText>
                     <CardTopOriginalAuthorText
                         references={props.post.references}
-                        navigate={props.navigate}
+                        navigation={props.navigation}
                     />
                 </View>
                 <RegularText style={styles.location}>{printableTime}{hostnameText}</RegularText>

--- a/src/components/DebugScreen.tsx
+++ b/src/components/DebugScreen.tsx
@@ -15,10 +15,11 @@ import { RowItem } from '../ui/misc/RowButton';
 import * as Swarm from '../swarm/Swarm';
 import { restartApp } from '../helpers/restart';
 import { Utils } from '../Utils';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
 export interface StateProps {
     appState: AppState;
-    navigation: any;
+    navigation: TypedNavigation;
 }
 
 export interface DispatchProps {
@@ -98,7 +99,7 @@ export const DebugScreen = (props: Props) => (
                         <MaterialCommunityIcon name='backup-restore' />
                     }
                     title='Backup & Restore'
-                    onPress={() => props.navigation.navigate('BackupRestore')}
+                    onPress={() => props.navigation.navigate<Routes, 'BackupRestore'>('BackupRestore', {})}
                     buttonStyle='none'
                 />
                 <RowItem
@@ -106,7 +107,7 @@ export const DebugScreen = (props: Props) => (
                         <MaterialCommunityIcon name='server-network' />
                     }
                     title='Swarm settings'
-                    onPress={async () => props.navigation.navigate('SwarmSettingsContainer')}
+                    onPress={async () => props.navigation.navigate<Routes, 'SwarmSettingsContainer'>('SwarmSettingsContainer', {})}
                     buttonStyle='none'
                 />
                 <RowItem
@@ -114,7 +115,7 @@ export const DebugScreen = (props: Props) => (
                         <IonIcon name='md-list' />
                     }
                     title='View logs'
-                    onPress={() => props.navigation.navigate('LogViewer')}
+                    onPress={() => props.navigation.navigate<Routes, 'LogViewer'>('LogViewer', {})}
                     buttonStyle='none'
                 />
             </ScrollView>

--- a/src/components/DebugScreen.tsx
+++ b/src/components/DebugScreen.tsx
@@ -99,7 +99,7 @@ export const DebugScreen = (props: Props) => (
                         <MaterialCommunityIcon name='backup-restore' />
                     }
                     title='Backup & Restore'
-                    onPress={() => props.navigation.navigate<Routes, 'BackupRestore'>('BackupRestore', {})}
+                    onPress={() => props.navigation.navigate('BackupRestore', {})}
                     buttonStyle='none'
                 />
                 <RowItem
@@ -107,7 +107,7 @@ export const DebugScreen = (props: Props) => (
                         <MaterialCommunityIcon name='server-network' />
                     }
                     title='Swarm settings'
-                    onPress={async () => props.navigation.navigate<Routes, 'SwarmSettingsContainer'>('SwarmSettingsContainer', {})}
+                    onPress={async () => props.navigation.navigate('SwarmSettingsContainer', {})}
                     buttonStyle='none'
                 />
                 <RowItem
@@ -115,7 +115,7 @@ export const DebugScreen = (props: Props) => (
                         <IonIcon name='md-list' />
                     }
                     title='View logs'
-                    onPress={() => props.navigation.navigate<Routes, 'LogViewer'>('LogViewer', {})}
+                    onPress={() => props.navigation.navigate('LogViewer', {})}
                     buttonStyle='none'
                 />
             </ScrollView>

--- a/src/components/EditFilter.tsx
+++ b/src/components/EditFilter.tsx
@@ -15,6 +15,7 @@ import { HOUR, DAY, MONTH31, WEEK } from '../DateUtils';
 import { SimpleTextInput } from './SimpleTextInput';
 import { Debug } from '../Debug';
 import { NavigationHeader } from './NavigationHeader';
+import { TypedNavigation } from '../helpers/navigation';
 
 type SliderValue = 0 | 1 | 2 | 3 | 4 | 5;
 
@@ -53,7 +54,7 @@ export interface DispatchProps {
 
 export interface StateProps {
     filter: ContentFilter;
-    navigation: any;
+    navigation: TypedNavigation;
 }
 
 type Props = DispatchProps & StateProps;

--- a/src/components/FavoritesFeedView.tsx
+++ b/src/components/FavoritesFeedView.tsx
@@ -10,13 +10,14 @@ import { PlaceholderCard } from '../ui/misc/PlaceholderCard';
 
 // @ts-ignore
 import SnorkelingIcon from '../../images/snorkeling.svg';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
 export interface DispatchProps {
     onRefreshPosts: (feeds: Feed[]) => void;
 }
 
 export interface StateProps {
-    navigation: any;
+    navigation: TypedNavigation;
     posts: Post[];
     feeds: Feed[];
     gatewayAddress: string;
@@ -36,7 +37,7 @@ export const FavoritesFeedView = (props: Props) => {
                     <NavigationHeader
                         title='Favorites'
                         rightButton1={{
-                            onPress: () => props.navigation.navigate(
+                            onPress: () => props.navigation.navigate<Routes, 'FeedListViewerContainer'>(
                                 'FeedListViewerContainer', {
                                     feeds: props.feeds,
                                     showExplore: false,

--- a/src/components/FavoritesFeedView.tsx
+++ b/src/components/FavoritesFeedView.tsx
@@ -37,7 +37,7 @@ export const FavoritesFeedView = (props: Props) => {
                     <NavigationHeader
                         title='Favorites'
                         rightButton1={{
-                            onPress: () => props.navigation.navigate<Routes, 'FeedListViewerContainer'>(
+                            onPress: () => props.navigation.navigate(
                                 'FeedListViewerContainer', {
                                     feeds: props.feeds,
                                     showExplore: false,

--- a/src/components/FeedHeader.tsx
+++ b/src/components/FeedHeader.tsx
@@ -41,7 +41,7 @@ export class FeedHeader extends React.PureComponent<Props> {
             createdAt: Date.now(),
         };
         this.props.onSaveDraft(post);
-        this.props.navigation.navigate<Routes, 'Post'>('Post', {});
+        this.props.navigation.navigate('Post', {});
     }
 
     public render() {
@@ -53,7 +53,7 @@ export class FeedHeader extends React.PureComponent<Props> {
                 <ProfileIcon profileImage={this.props.profileImage} gatewayAddress={this.props.gatewayAddress}/>
                 <TouchableView
                     onPress={() =>
-                        this.props.navigation.navigate<Routes, 'Post'>('Post', {})
+                        this.props.navigation.navigate('Post', {})
                     }
                     style={styles.headerTextContainer}
                     hitSlop={{

--- a/src/components/FeedHeader.tsx
+++ b/src/components/FeedHeader.tsx
@@ -14,9 +14,10 @@ import { DefaultStyle, Colors } from '../styles';
 import { RegularText } from '../ui/misc/text';
 import { ImageData } from '../models/ImageData';
 import { ReactNativeModelHelper } from '../models/ReactNativeModelHelper';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
 export interface StateProps {
-    navigation: any;
+    navigation: TypedNavigation;
     profileImage: ImageData;
     gatewayAddress: string;
 }
@@ -40,7 +41,7 @@ export class FeedHeader extends React.PureComponent<Props> {
             createdAt: Date.now(),
         };
         this.props.onSaveDraft(post);
-        this.props.navigation.navigate('Post');
+        this.props.navigation.navigate<Routes, 'Post'>('Post', {});
     }
 
     public render() {
@@ -52,7 +53,7 @@ export class FeedHeader extends React.PureComponent<Props> {
                 <ProfileIcon profileImage={this.props.profileImage} gatewayAddress={this.props.gatewayAddress}/>
                 <TouchableView
                     onPress={() =>
-                        this.props.navigation.navigate('Post')
+                        this.props.navigation.navigate<Routes, 'Post'>('Post', {})
                     }
                     style={styles.headerTextContainer}
                     hitSlop={{

--- a/src/components/FeedInfo.tsx
+++ b/src/components/FeedInfo.tsx
@@ -23,6 +23,7 @@ import { downloadRecentPostFeed } from '../swarm-social/swarmStorage';
 import { NavigationHeader } from './NavigationHeader';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { unfollowFeed } from './FeedView';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
 const QRCodeWidth = Dimensions.get('window').width * 0.6;
 const QRCodeHeight = QRCodeWidth;
@@ -45,7 +46,7 @@ export interface DispatchProps {
 export interface StateProps {
     swarmGateway: string;
     feed: Feed;
-    navigation: any;
+    navigation: TypedNavigation;
     isKnownFeed: boolean;
 }
 
@@ -96,7 +97,10 @@ export class FeedInfo extends React.Component<Props, FeedInfoState> {
                 onSuccess();
             }
             this.onAdd(feed);
-            this.props.navigation.navigate('Feed', { feedUrl: feed.feedUrl, name: feed.name });
+            this.props.navigation.navigate<Routes, 'Feed'>('Feed', {
+                feedUrl: feed.feedUrl,
+                name: feed.name,
+            });
         } else {
             this.onFailedFeedLoad();
         }

--- a/src/components/FeedInfo.tsx
+++ b/src/components/FeedInfo.tsx
@@ -97,7 +97,7 @@ export class FeedInfo extends React.Component<Props, FeedInfoState> {
                 onSuccess();
             }
             this.onAdd(feed);
-            this.props.navigation.navigate<Routes, 'Feed'>('Feed', {
+            this.props.navigation.navigate('Feed', {
                 feedUrl: feed.feedUrl,
                 name: feed.name,
             });

--- a/src/components/FeedListEditor.tsx
+++ b/src/components/FeedListEditor.tsx
@@ -11,14 +11,15 @@ import { GridCard, getGridCardSize } from '../ui/misc/GridCard';
 import { ReactNativeModelHelper } from '../models/ReactNativeModelHelper';
 import { MediumText } from '../ui/misc/text';
 import { TabBarPlaceholder } from '../ui/misc/TabBarPlaceholder';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
 export interface DispatchProps {
-    onPressFeed: (navigation: any, feed: Feed) => void;
+    onPressFeed: (feed: Feed) => void;
     openExplore: () => void;
 }
 
 export interface StateProps {
-    navigation: any;
+    navigation: TypedNavigation;
     ownFeeds: Feed[];
     followedFeeds: Feed[];
     knownFeeds: Feed[];
@@ -65,7 +66,7 @@ export class FeedGrid extends React.PureComponent<DispatchProps & StateProps & {
                             <GridCard
                                 title={item.name}
                                 imageUri={imageUri}
-                                onPress={() => this.props.onPressFeed(this.props.navigation, item)}
+                                onPress={() => this.props.onPressFeed(item)}
                                 size={itemDimension}
                                 modelHelper={modelHelper}
                             />
@@ -124,7 +125,7 @@ export class FeedListEditor extends React.PureComponent<DispatchProps & StatePro
             name: '',
             url: '',
         };
-        this.props.navigation.navigate('FeedInfo', { feed: feed });
+        this.props.navigation.navigate<Routes, 'FeedInfo'>('FeedInfo', { feed: feed });
     }
 }
 

--- a/src/components/FeedListEditor.tsx
+++ b/src/components/FeedListEditor.tsx
@@ -125,7 +125,7 @@ export class FeedListEditor extends React.PureComponent<DispatchProps & StatePro
             name: '',
             url: '',
         };
-        this.props.navigation.navigate<Routes, 'FeedInfo'>('FeedInfo', { feed: feed });
+        this.props.navigation.navigate('FeedInfo', { feed: feed });
     }
 }
 

--- a/src/components/FeedView.tsx
+++ b/src/components/FeedView.tsx
@@ -9,6 +9,8 @@ import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import * as AreYouSureDialog from './AreYouSureDialog';
 import { ReactNativeModelHelper } from '../models/ReactNativeModelHelper';
 import { FELFELE_ASSISTANT_URL } from '../reducers/defaultData';
+import { TypedNavigation, Routes } from '../helpers/navigation';
+import { LocalFeed } from '../social/api';
 
 export interface DispatchProps {
     onRefreshPosts: (feeds: Feed[]) => void;
@@ -19,7 +21,7 @@ export interface DispatchProps {
 }
 
 export interface StateProps {
-    navigation: any;
+    navigation: TypedNavigation;
     onBack: () => void;
     feedUrl: string;
     feedName: string;
@@ -42,11 +44,11 @@ export const FeedView = (props: Props) => {
         onPress,
     });
     const toggleFavorite = () => props.onToggleFavorite(props.feedUrl);
-    const navigateToFeedSettings = () => props.navigation.navigate(
+    const navigateToFeedSettings = () => props.navigation.navigate<Routes, 'FeedSettings'>(
         'FeedSettings',
-        { feed: props.feeds[0] },
+        { feed: props.feeds[0] as LocalFeed },
     );
-    const navigateToFeedInfo = () => props.navigation.navigate(
+    const navigateToFeedInfo = () => props.navigation.navigate<Routes, 'FeedInfo'>(
         'FeedInfo', {
             feed: props.feeds[0],
         }

--- a/src/components/FeedView.tsx
+++ b/src/components/FeedView.tsx
@@ -9,7 +9,7 @@ import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import * as AreYouSureDialog from './AreYouSureDialog';
 import { ReactNativeModelHelper } from '../models/ReactNativeModelHelper';
 import { FELFELE_ASSISTANT_URL } from '../reducers/defaultData';
-import { TypedNavigation, Routes } from '../helpers/navigation';
+import { TypedNavigation } from '../helpers/navigation';
 import { LocalFeed } from '../social/api';
 
 export interface DispatchProps {

--- a/src/components/FeedView.tsx
+++ b/src/components/FeedView.tsx
@@ -44,11 +44,11 @@ export const FeedView = (props: Props) => {
         onPress,
     });
     const toggleFavorite = () => props.onToggleFavorite(props.feedUrl);
-    const navigateToFeedSettings = () => props.navigation.navigate<Routes, 'FeedSettings'>(
+    const navigateToFeedSettings = () => props.navigation.navigate(
         'FeedSettings',
         { feed: props.feeds[0] as LocalFeed },
     );
-    const navigateToFeedInfo = () => props.navigation.navigate<Routes, 'FeedInfo'>(
+    const navigateToFeedInfo = () => props.navigation.navigate(
         'FeedInfo', {
             feed: props.feeds[0],
         }

--- a/src/components/FilterListEditor.tsx
+++ b/src/components/FilterListEditor.tsx
@@ -6,9 +6,10 @@ import { DateUtils } from '../DateUtils';
 import { NavigationHeader } from './NavigationHeader';
 import { Colors } from '../styles';
 import { RowItem } from '../ui/misc/RowButton';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
 export interface StateProps {
-    navigation: any;
+    navigation: TypedNavigation;
     filters: ContentFilter[];
 }
 
@@ -48,7 +49,7 @@ export class FilterListEditor extends React.Component<StateProps & DispatchProps
     }
 
     private editFilter = (filter: ContentFilter) => {
-        this.props.navigation.navigate('EditFilter', { filter: filter });
+        this.props.navigation.navigate<Routes, 'EditFilter'>('EditFilter', { filter: filter });
     }
 
     private onAddFilter = () => {
@@ -57,7 +58,7 @@ export class FilterListEditor extends React.Component<StateProps & DispatchProps
             createdAt: 0,
             validUntil: 0,
         };
-        this.props.navigation.navigate('EditFilter', { filter: filter });
+        this.props.navigation.navigate<Routes, 'EditFilter'>('EditFilter', { filter: filter });
     }
 }
 

--- a/src/components/FilterListEditor.tsx
+++ b/src/components/FilterListEditor.tsx
@@ -49,7 +49,7 @@ export class FilterListEditor extends React.Component<StateProps & DispatchProps
     }
 
     private editFilter = (filter: ContentFilter) => {
-        this.props.navigation.navigate<Routes, 'EditFilter'>('EditFilter', { filter: filter });
+        this.props.navigation.navigate('EditFilter', { filter: filter });
     }
 
     private onAddFilter = () => {
@@ -58,7 +58,7 @@ export class FilterListEditor extends React.Component<StateProps & DispatchProps
             createdAt: 0,
             validUntil: 0,
         };
-        this.props.navigation.navigate<Routes, 'EditFilter'>('EditFilter', { filter: filter });
+        this.props.navigation.navigate('EditFilter', { filter: filter });
     }
 }
 

--- a/src/components/IdentitySettings.tsx
+++ b/src/components/IdentitySettings.tsx
@@ -136,7 +136,7 @@ export const IdentitySettings = (props: DispatchProps & StateProps) => {
                     <RowItem
                         title={VIEW_POSTS_LABEL}
                         buttonStyle='navigate'
-                        onPress={() => props.navigation.navigate<Routes, 'YourTab'>('YourTab', {})}
+                        onPress={() => props.navigation.navigate('YourTab', {})}
                     />
                     { props.ownFeed &&
                         <View style={styles.qrCodeContainer}>

--- a/src/components/IdentitySettings.tsx
+++ b/src/components/IdentitySettings.tsx
@@ -32,6 +32,7 @@ import { RowItem } from '../ui/misc/RowButton';
 import { RegularText } from '../ui/misc/text';
 import { TabBarPlaceholder } from '../ui/misc/TabBarPlaceholder';
 import { DEFAULT_AUTHOR_NAME } from '../reducers/defaultData';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
 export interface DispatchProps {
     onUpdateAuthor: (text: string) => void;
@@ -42,7 +43,7 @@ export interface DispatchProps {
 export interface StateProps {
     author: Author;
     ownFeed?: Feed;
-    navigation: any;
+    navigation: TypedNavigation;
     gatewayAddress: string;
 }
 
@@ -135,7 +136,7 @@ export const IdentitySettings = (props: DispatchProps & StateProps) => {
                     <RowItem
                         title={VIEW_POSTS_LABEL}
                         buttonStyle='navigate'
-                        onPress={() => props.navigation.navigate('YourTab')}
+                        onPress={() => props.navigation.navigate<Routes, 'YourTab'>('YourTab', {})}
                     />
                     { props.ownFeed &&
                         <View style={styles.qrCodeContainer}>

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -3,18 +3,21 @@ import {
     View,
 } from 'react-native';
 import { Author } from '../models/Author';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
 export interface DispatchProps { }
 
 export interface StateProps {
     author: Author;
-    navigation: any;
+    navigation: TypedNavigation;
 }
 
 export const LoadingScreen = (props: DispatchProps & StateProps) => {
     return (
         <View>
-            {props.author.identity == null ? props.navigation.navigate('Welcome') : props.navigation.navigate('App')}
+            {props.author.identity == null
+                ? props.navigation.navigate<Routes, 'Welcome'>('Welcome', {}) :
+                props.navigation.navigate<Routes, 'App'>('App', {})}
         </View>
     );
 };

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -16,8 +16,8 @@ export const LoadingScreen = (props: DispatchProps & StateProps) => {
     return (
         <View>
             {props.author.identity == null
-                ? props.navigation.navigate<Routes, 'Welcome'>('Welcome', {}) :
-                props.navigation.navigate<Routes, 'App'>('App', {})}
+                ? props.navigation.navigate('Welcome', {}) :
+                props.navigation.navigate('App', {})}
         </View>
     );
 };

--- a/src/components/LogViewer.tsx
+++ b/src/components/LogViewer.tsx
@@ -13,10 +13,11 @@ import { NavigationHeader } from './NavigationHeader';
 import { clearLog, filteredLog, setLogFilter } from '../log';
 import { Colors, DefaultTabBarHeight } from '../styles';
 import { SimpleTextInput } from './SimpleTextInput';
+import { TypedNavigation } from '../helpers/navigation';
 
 export interface StateProps {
     currentTimestamp: number;
-    navigation: any;
+    navigation: TypedNavigation;
 }
 
 export interface DispatchProps {

--- a/src/components/PostEditor.tsx
+++ b/src/components/PostEditor.tsx
@@ -24,9 +24,10 @@ import { Avatar } from '../ui/misc/Avatar';
 import { ReactNativeModelHelper } from '../models/ReactNativeModelHelper';
 import { ModelHelper } from '../models/ModelHelper';
 import { TouchableViewDefaultHitSlop } from './TouchableView';
+import { TypedNavigation } from '../helpers/navigation';
 
 export interface StateProps {
-    navigation: any;
+    navigation: TypedNavigation;
     draft: Post | null;
     name: string;
     avatar: ImageData;

--- a/src/components/RefreshableFeed.tsx
+++ b/src/components/RefreshableFeed.tsx
@@ -15,13 +15,14 @@ import { CardContainer } from '../containers/CardContainer';
 import { Props as NavHeaderProps } from './NavigationHeader';
 import { Props as FeedHeaderProps } from './FeedHeader';
 import { ModelHelper } from '../models/ModelHelper';
+import { TypedNavigation } from '../helpers/navigation';
 
 export interface DispatchProps {
     onRefreshPosts: (feeds: Feed[]) => void;
 }
 
 export interface StateProps {
-    navigation: any;
+    navigation: TypedNavigation;
     posts: Post[];
     feeds: Feed[];
     modelHelper: ModelHelper;
@@ -82,7 +83,7 @@ export class RefreshableFeed extends React.PureComponent<Props, RefreshableFeedS
                         <CardContainer
                             post={obj.item}
                             isSelected={this.isPostSelected(obj.item)}
-                            navigate={this.props.navigation.navigate}
+                            navigation={this.props.navigation}
                             togglePostSelection={this.togglePostSelection}
                             modelHelper={this.props.modelHelper}
                         />

--- a/src/components/Restore.tsx
+++ b/src/components/Restore.tsx
@@ -8,9 +8,10 @@ import { Button } from './Button';
 import { isValidBackup, restoreBackupToString } from '../BackupRestore';
 import { stringToHex } from '../conversion';
 import { getAppStateFromSerialized } from '../reducers';
+import { TypedNavigation } from '../helpers/navigation';
 
 export interface StateProps {
-    navigation: any;
+    navigation: TypedNavigation;
 }
 
 export interface DispatchProps {

--- a/src/components/SettingsEditor.tsx
+++ b/src/components/SettingsEditor.tsx
@@ -56,7 +56,7 @@ export const SettingsEditor = (props: Props) => {
                                 <GridCard
                                     title={item.name}
                                     imageUri={modelHelper.getImageUri(item.authorImage)}
-                                    onPress={() => props.navigation.navigate<Routes, 'FeedSettings'>('FeedSettings', { feed: item as any })}
+                                    onPress={() => props.navigation.navigate('FeedSettings', { feed: item as any })}
                                     size={itemDimension}
                                     modelHelper={modelHelper}
                                 />
@@ -88,12 +88,12 @@ export const SettingsEditor = (props: Props) => {
                 <RowItem
                     title='Filters'
                     buttonStyle='navigate'
-                    onPress={() => props.navigation.navigate<Routes, 'FilterListEditorContainer'>('FilterListEditorContainer', {})}
+                    onPress={() => props.navigation.navigate('FilterListEditorContainer', {})}
                 />
                 <RowItem
                     title='Send bug report'
                     buttonStyle='navigate'
-                    onPress={() => props.navigation.navigate<Routes, 'BugReportView'>('BugReportView', {})}
+                    onPress={() => props.navigation.navigate('BugReportView', {})}
                     />
                 <RowItem
                     title={version}
@@ -107,7 +107,7 @@ export const SettingsEditor = (props: Props) => {
                     }
                     title='Debug menu'
                     buttonStyle='navigate'
-                    onPress={() => props.navigation.navigate<Routes, 'Debug'>('Debug', {})}
+                    onPress={() => props.navigation.navigate('Debug', {})}
                 />
                 }
             </ScrollView>

--- a/src/components/SettingsEditor.tsx
+++ b/src/components/SettingsEditor.tsx
@@ -13,9 +13,10 @@ import { GridCard, getGridCardSize, GRID_SPACING } from '../ui/misc/GridCard';
 import { RegularText, MediumText } from '../ui/misc/text';
 import { RecentPostFeed } from '../social/api';
 import { TabBarPlaceholder } from '../ui/misc/TabBarPlaceholder';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
 export interface StateProps {
-    navigation: any;
+    navigation: TypedNavigation;
     settings: Settings;
     ownFeeds: RecentPostFeed[];
 }
@@ -55,7 +56,7 @@ export const SettingsEditor = (props: Props) => {
                                 <GridCard
                                     title={item.name}
                                     imageUri={modelHelper.getImageUri(item.authorImage)}
-                                    onPress={() => props.navigation.navigate('FeedSettings', { feed: item })}
+                                    onPress={() => props.navigation.navigate<Routes, 'FeedSettings'>('FeedSettings', { feed: item as any })}
                                     size={itemDimension}
                                     modelHelper={modelHelper}
                                 />
@@ -87,12 +88,12 @@ export const SettingsEditor = (props: Props) => {
                 <RowItem
                     title='Filters'
                     buttonStyle='navigate'
-                    onPress={() => props.navigation.navigate('FilterListEditorContainer')}
+                    onPress={() => props.navigation.navigate<Routes, 'FilterListEditorContainer'>('FilterListEditorContainer', {})}
                 />
                 <RowItem
                     title='Send bug report'
                     buttonStyle='navigate'
-                    onPress={() => props.navigation.navigate('BugReportView')}
+                    onPress={() => props.navigation.navigate<Routes, 'BugReportView'>('BugReportView', {})}
                     />
                 <RowItem
                     title={version}
@@ -106,7 +107,7 @@ export const SettingsEditor = (props: Props) => {
                     }
                     title='Debug menu'
                     buttonStyle='navigate'
-                    onPress={() => props.navigation.navigate('Debug')}
+                    onPress={() => props.navigation.navigate<Routes, 'Debug'>('Debug', {})}
                 />
                 }
             </ScrollView>

--- a/src/components/SwarmSettings.tsx
+++ b/src/components/SwarmSettings.tsx
@@ -11,10 +11,11 @@ import {
 import { NavigationHeader } from './NavigationHeader';
 import { SimpleTextInput } from './SimpleTextInput';
 import { Colors } from '../styles';
+import { TypedNavigation } from '../helpers/navigation';
 
 export interface StateProps {
     swarmGatewayAddress: string;
-    navigation: any;
+    navigation: TypedNavigation;
 }
 
 export interface DispatchProps {

--- a/src/components/Welcome.tsx
+++ b/src/components/Welcome.tsx
@@ -10,14 +10,15 @@ import { ImageData } from '../models/ImageData';
 import SplashScreen from 'react-native-splash-screen';
 import { Colors } from '../styles';
 import { defaultAuthor } from '../reducers/defaultData';
+import { TypedNavigation } from '../helpers/navigation';
 
 export interface DispatchProps {
     onStartDownloadFeeds: () => void;
-    onCreateUser: (name: string, image: ImageData, navigation: any) => void;
+    onCreateUser: (name: string, image: ImageData, navigation: TypedNavigation) => void;
 }
 
 export interface StateProps {
-    navigation: any;
+    navigation: TypedNavigation;
     gatewayAddress: string;
 }
 

--- a/src/components/YourFeedView.tsx
+++ b/src/components/YourFeedView.tsx
@@ -6,6 +6,7 @@ import { FeedHeader } from './FeedHeader';
 import { NavigationHeader } from './NavigationHeader';
 import { ImageData } from '../models/ImageData';
 import { ReactNativeModelHelper } from '../models/ReactNativeModelHelper';
+import { TypedNavigation } from '../helpers/navigation';
 
 export interface DispatchProps {
     onRefreshPosts: (feeds: Feed[]) => void;
@@ -13,7 +14,7 @@ export interface DispatchProps {
 }
 
 export interface StateProps {
-    navigation: any;
+    navigation: TypedNavigation;
     posts: Post[];
     feeds: Feed[];
     profileImage: ImageData;

--- a/src/containers/AllFeedContainer.ts
+++ b/src/containers/AllFeedContainer.ts
@@ -6,8 +6,9 @@ import { Feed } from '../models/Feed';
 import { StateProps, DispatchProps, AllFeedScreen } from '../components/AllFeedScreen';
 import { getAllFeeds, getAllPostsSorted } from '../selectors/selectors';
 import { Post } from '../models/Post';
+import { TypedNavigation } from '../helpers/navigation';
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     const followedFeeds = getAllFeeds(state);
     const filteredPosts = getAllPostsSorted(state);
 

--- a/src/containers/BackupContainer.ts
+++ b/src/containers/BackupContainer.ts
@@ -1,8 +1,9 @@
 import { connect } from 'react-redux';
 import { AppState } from '../reducers/AppState';
 import { StateProps, DispatchProps, Backup } from '../components/Backup';
+import { TypedNavigation } from '../helpers/navigation';
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     return {
         navigation: ownProps.navigation,
         appState: state,

--- a/src/containers/CardContainer.ts
+++ b/src/containers/CardContainer.ts
@@ -4,13 +4,14 @@ import { StateProps, DispatchProps, MemoizedCard } from '../components/Card';
 import { Post } from '../models/Post';
 import { AsyncActions } from '../actions/Actions';
 import { ModelHelper } from '../models/ModelHelper';
+import { TypedNavigation } from '../helpers/navigation';
 
 interface OwnProps {
     isSelected: boolean;
     post: Post;
     modelHelper: ModelHelper;
     togglePostSelection: (post: Post) => void;
-    navigate: (view: string, {}) => void;
+    navigation: TypedNavigation;
 }
 
 const mapStateToProps = (state: AppState, ownProps: OwnProps): StateProps => {
@@ -22,7 +23,7 @@ const mapStateToProps = (state: AppState, ownProps: OwnProps): StateProps => {
         author: state.author,
         modelHelper: ownProps.modelHelper,
         togglePostSelection: ownProps.togglePostSelection,
-        navigate: ownProps.navigate,
+        navigation: ownProps.navigation,
     };
 };
 

--- a/src/containers/DebugScreenContainer.ts
+++ b/src/containers/DebugScreenContainer.ts
@@ -3,8 +3,9 @@ import { AppState } from '../reducers/AppState';
 import { AsyncActions, Actions } from '../actions/Actions';
 import { StateProps, DispatchProps, DebugScreen } from '../components/DebugScreen';
 import { Post } from '../models/Post';
+import { TypedNavigation } from '../helpers/navigation';
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
    return {
        navigation: ownProps.navigation,
        appState: state,

--- a/src/containers/EditFilterContainer.ts
+++ b/src/containers/EditFilterContainer.ts
@@ -2,12 +2,12 @@ import { connect } from 'react-redux';
 import { AppState } from '../reducers/AppState';
 import { Actions } from '../actions/Actions';
 import { StateProps, DispatchProps, EditFilter } from '../components/EditFilter';
-import { Feed } from '../models/Feed';
 import { ContentFilter } from '../models/ContentFilter';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     return {
-        filter: ownProps.navigation.state.params.filter,
+        filter: ownProps.navigation.getParam<Routes['EditFilter'], 'filter'>('filter'),
         navigation: ownProps.navigation,
     };
 };

--- a/src/containers/EditFilterContainer.ts
+++ b/src/containers/EditFilterContainer.ts
@@ -3,11 +3,11 @@ import { AppState } from '../reducers/AppState';
 import { Actions } from '../actions/Actions';
 import { StateProps, DispatchProps, EditFilter } from '../components/EditFilter';
 import { ContentFilter } from '../models/ContentFilter';
-import { TypedNavigation, Routes } from '../helpers/navigation';
+import { TypedNavigation } from '../helpers/navigation';
 
 const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     return {
-        filter: ownProps.navigation.getParam<Routes['EditFilter'], 'filter'>('filter'),
+        filter: ownProps.navigation.getParam<'EditFilter', 'filter'>('filter'),
         navigation: ownProps.navigation,
     };
 };

--- a/src/containers/FavoritesContainer.ts
+++ b/src/containers/FavoritesContainer.ts
@@ -5,8 +5,9 @@ import { AsyncActions } from '../actions/Actions';
 import { Feed } from '../models/Feed';
 import { FavoritesFeedView } from '../components/FavoritesFeedView';
 import { getFavoriteFeedsPosts, getFavoriteFeeds } from '../selectors/selectors';
+import { TypedNavigation } from '../helpers/navigation';
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     const posts = getFavoriteFeedsPosts(state);
     const favoriteFeeds = getFavoriteFeeds(state);
 

--- a/src/containers/FeedContainer.ts
+++ b/src/containers/FeedContainer.ts
@@ -7,8 +7,8 @@ import { getFeedPosts, getYourPosts } from '../selectors/selectors';
 import { TypedNavigation, Routes } from '../helpers/navigation';
 
 export const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
-    const feedUrl = ownProps.navigation.getParam<Routes['Feed'], 'feedUrl'>('feedUrl');
-    const feedName = ownProps.navigation.getParam<Routes['Feed'], 'name'>('name');
+    const feedUrl = ownProps.navigation.getParam<'Feed', 'feedUrl'>('feedUrl');
+    const feedName = ownProps.navigation.getParam<'Feed', 'name'>('name');
 
     const isOwnFeed = feedName === state.author.name;
     const hasOwnFeed = state.ownFeeds.length > 0;

--- a/src/containers/FeedContainer.ts
+++ b/src/containers/FeedContainer.ts
@@ -4,10 +4,11 @@ import { StateProps, DispatchProps, FeedView } from '../components/FeedView';
 import { AsyncActions, Actions } from '../actions/Actions';
 import { Feed } from '../models/Feed';
 import { getFeedPosts, getYourPosts } from '../selectors/selectors';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
-export const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
-    const feedUrl = ownProps.navigation.state.params.feedUrl;
-    const feedName = ownProps.navigation.state.params.name;
+export const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
+    const feedUrl = ownProps.navigation.getParam<Routes['Feed'], 'feedUrl'>('feedUrl');
+    const feedName = ownProps.navigation.getParam<Routes['Feed'], 'name'>('name');
 
     const isOwnFeed = feedName === state.author.name;
     const hasOwnFeed = state.ownFeeds.length > 0;

--- a/src/containers/FeedInfoContainer.ts
+++ b/src/containers/FeedInfoContainer.ts
@@ -8,7 +8,7 @@ import { TypedNavigation, Routes } from '../helpers/navigation';
 const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     // this fixes rerendering after unfollow
     updateNavParam(state.feeds, ownProps.navigation);
-    const navParamFeed = ownProps.navigation.getParam<Routes['FeedInfo'], 'feed'>('feed');
+    const navParamFeed = ownProps.navigation.getParam<'FeedInfo', 'feed'>('feed');
     const isKnownFeed = state.feeds.find(feed => navParamFeed.feedUrl === feed.feedUrl) != null;
 
     return {
@@ -20,12 +20,12 @@ const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigatio
 };
 
 const updateNavParam = (feeds: Feed[], navigation: TypedNavigation) => {
-    const feedUrl = navigation.getParam<Routes['FeedInfo'], 'feed'>('feed').feedUrl;
-    const isFollowed = navigation.getParam<Routes['FeedInfo'], 'feed'>('feed').followed;
+    const feedUrl = navigation.getParam<'FeedInfo', 'feed'>('feed').feedUrl;
+    const isFollowed = navigation.getParam<'FeedInfo', 'feed'>('feed').followed;
 
     const updatedFeed = feeds.find(feed => feed.feedUrl === feedUrl);
     if (updatedFeed != null && updatedFeed.followed !== isFollowed) {
-        navigation.setParams<Routes['FeedInfo']>({ feed: updatedFeed });
+        navigation.setParams<'FeedInfo'>({ feed: updatedFeed });
     }
 };
 

--- a/src/containers/FeedInfoContainer.ts
+++ b/src/containers/FeedInfoContainer.ts
@@ -3,11 +3,12 @@ import { AppState } from '../reducers/AppState';
 import { Actions, AsyncActions } from '../actions/Actions';
 import { StateProps, DispatchProps, FeedInfo } from '../components/FeedInfo';
 import { Feed } from '../models/Feed';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     // this fixes rerendering after unfollow
     updateNavParam(state.feeds, ownProps.navigation);
-    const navParamFeed = ownProps.navigation.state.params.feed;
+    const navParamFeed = ownProps.navigation.getParam<Routes['FeedInfo'], 'feed'>('feed');
     const isKnownFeed = state.feeds.find(feed => navParamFeed.feedUrl === feed.feedUrl) != null;
 
     return {
@@ -18,14 +19,17 @@ const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateP
     };
 };
 
-const updateNavParam = (feeds: Feed[], navigation: any) => {
-    const updatedFeed = feeds.find(feed => feed.feedUrl === navigation.state.params.feed.feedUrl);
-    if (updatedFeed != null && updatedFeed.followed !== navigation.state.params.feed.followed) {
-        navigation.setParams({ feed: updatedFeed });
+const updateNavParam = (feeds: Feed[], navigation: TypedNavigation) => {
+    const feedUrl = navigation.getParam<Routes['FeedInfo'], 'feed'>('feed').feedUrl;
+    const isFollowed = navigation.getParam<Routes['FeedInfo'], 'feed'>('feed').followed;
+
+    const updatedFeed = feeds.find(feed => feed.feedUrl === feedUrl);
+    if (updatedFeed != null && updatedFeed.followed !== isFollowed) {
+        navigation.setParams<Routes['FeedInfo']>({ feed: updatedFeed });
     }
 };
 
-const mapDispatchToProps = (dispatch: any, ownProps: { navigation: any }): DispatchProps => {
+const mapDispatchToProps = (dispatch: any, ownProps: { navigation: TypedNavigation }): DispatchProps => {
     return {
         onAddFeed: (feed: Feed) => {
             dispatch(Actions.addFeed(feed));

--- a/src/containers/FeedListViewerContainer.ts
+++ b/src/containers/FeedListViewerContainer.ts
@@ -14,8 +14,8 @@ export const sortFeeds = (feeds: Feed[]): Feed[] => feeds.sort((a, b) => favorit
 
 const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation, showExplore: boolean }): StateProps => {
     // TODO: update favicons?
-    const navParamFeeds = ownProps.navigation.getParam<Routes['FeedListViewerContainer'], 'feeds'>('feeds');
-    const navParamShowExplore = ownProps.navigation.getParam<Routes['FeedListViewerContainer'], 'showExplore'>('showExplore');
+    const navParamFeeds = ownProps.navigation.getParam<'FeedListViewerContainer', 'feeds'>('feeds');
+    const navParamShowExplore = ownProps.navigation.getParam<'FeedListViewerContainer', 'showExplore'>('showExplore');
     const ownFeeds = navParamFeeds
         ? []
         : state.ownFeeds

--- a/src/containers/FeedListViewerContainer.ts
+++ b/src/containers/FeedListViewerContainer.ts
@@ -42,10 +42,10 @@ const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigatio
 export const mapDispatchToProps = (dispatch: any, ownProps: { navigation: TypedNavigation }): DispatchProps => {
     return {
         openExplore: () => {
-            ownProps.navigation.navigate<Routes, 'CategoriesContainer'>('CategoriesContainer', {});
+            ownProps.navigation.navigate('CategoriesContainer', {});
         },
         onPressFeed: (feed: Feed) => {
-            ownProps.navigation.navigate<Routes, 'FeedFromList'>('FeedFromList', {
+            ownProps.navigation.navigate('FeedFromList', {
                 feedUrl: feed.feedUrl,
                 name: feed.name,
             });

--- a/src/containers/FeedListViewerContainer.ts
+++ b/src/containers/FeedListViewerContainer.ts
@@ -4,6 +4,7 @@ import { AppState } from '../reducers/AppState';
 import { StateProps, DispatchProps, FeedListEditor } from '../components/FeedListEditor';
 import { Feed } from '../models/Feed';
 import { getFollowedFeeds, getKnownFeeds } from '../selectors/selectors';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
 const favoriteCompare = (a: Feed, b: Feed): number => (b.favorite === true ? 1 : 0) - (a.favorite === true ? 1 : 0);
 
@@ -11,17 +12,19 @@ const followedCompare = (a: Feed, b: Feed): number => (b.followed === true ? 1 :
 
 export const sortFeeds = (feeds: Feed[]): Feed[] => feeds.sort((a, b) => favoriteCompare(a, b) || followedCompare (a, b) || a.name.localeCompare(b.name));
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any, showExplore: boolean }): StateProps => {
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation, showExplore: boolean }): StateProps => {
     // TODO: update favicons?
-    const ownFeeds = ownProps.navigation.state.params && ownProps.navigation.state.params.feeds
+    const navParamFeeds = ownProps.navigation.getParam<Routes['FeedListViewerContainer'], 'feeds'>('feeds');
+    const navParamShowExplore = ownProps.navigation.getParam<Routes['FeedListViewerContainer'], 'showExplore'>('showExplore');
+    const ownFeeds = navParamFeeds
         ? []
         : state.ownFeeds
     ;
-    const followedFeeds = ownProps.navigation.state.params && ownProps.navigation.state.params.feeds
-        ? ownProps.navigation.state.params.feeds
+    const followedFeeds = navParamFeeds
+        ? navParamFeeds
         : getFollowedFeeds(state)
     ;
-    const knownFeeds = ownProps.navigation.state.params && ownProps.navigation.state.params.feeds
+    const knownFeeds = navParamFeeds
         ? []
         : getKnownFeeds(state)
     ;
@@ -32,17 +35,20 @@ const mapStateToProps = (state: AppState, ownProps: { navigation: any, showExplo
         navigation: ownProps.navigation,
         gatewayAddress: state.settings.swarmGatewayAddress,
         title: 'All feeds',
-        showExplore: ownProps.navigation.state.params.showExplore,
+        showExplore: navParamShowExplore,
     };
 };
 
-export const mapDispatchToProps = (dispatch: any, ownProps: { navigation: any }): DispatchProps => {
+export const mapDispatchToProps = (dispatch: any, ownProps: { navigation: TypedNavigation }): DispatchProps => {
     return {
         openExplore: () => {
-            ownProps.navigation.navigate('CategoriesContainer');
+            ownProps.navigation.navigate<Routes, 'CategoriesContainer'>('CategoriesContainer', {});
         },
-        onPressFeed: (navigation: any, feed: Feed) => {
-            navigation.navigate('FeedFromList', { feedUrl: feed.feedUrl, name: feed.name });
+        onPressFeed: (feed: Feed) => {
+            ownProps.navigation.navigate<Routes, 'FeedFromList'>('FeedFromList', {
+                feedUrl: feed.feedUrl,
+                name: feed.name,
+            });
         },
     };
 };

--- a/src/containers/FilterListEditorContainer.ts
+++ b/src/containers/FilterListEditorContainer.ts
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import { AppState } from '../reducers/AppState';
 import { StateProps, DispatchProps, FilterListEditor } from '../components/FilterListEditor';
 import { ContentFilter } from '../models/ContentFilter';
+import { TypedNavigation } from '../helpers/navigation';
 
 const sortFilters = (a: ContentFilter, b: ContentFilter): number => {
     const aTimeUntil = a.createdAt + a.validUntil;
@@ -19,7 +20,7 @@ const sortFilters = (a: ContentFilter, b: ContentFilter): number => {
     return 0;
 };
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
    return {
        navigation: ownProps.navigation,
        filters: state.contentFilters.sort(sortFilters),

--- a/src/containers/IdentitySettingsContainer.ts
+++ b/src/containers/IdentitySettingsContainer.ts
@@ -3,8 +3,9 @@ import { AppState } from '../reducers/AppState';
 import { Actions } from '../actions/Actions';
 import { StateProps, DispatchProps, IdentitySettings } from '../components/IdentitySettings';
 import { ImageData} from '../models/ImageData';
+import { TypedNavigation } from '../helpers/navigation';
 
-export const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
+export const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     const ownFeed = state.ownFeeds.length > 0
         ? state.ownFeeds[0]
         : undefined;

--- a/src/containers/LoadingScreenContainer.ts
+++ b/src/containers/LoadingScreenContainer.ts
@@ -1,8 +1,9 @@
 import { connect } from 'react-redux';
 import { StateProps, DispatchProps, LoadingScreen } from '../components/LoadingScreen';
 import { AppState } from '../reducers/AppState';
+import { TypedNavigation } from '../helpers/navigation';
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     return {
         author: state.author,
         navigation: ownProps.navigation,

--- a/src/containers/LogViewerContainer.ts
+++ b/src/containers/LogViewerContainer.ts
@@ -2,8 +2,9 @@ import { connect } from 'react-redux';
 import { AppState } from '../reducers/AppState';
 import * as Actions from '../actions/Actions';
 import { StateProps, DispatchProps, LogViewer } from '../components/LogViewer';
+import { TypedNavigation } from '../helpers/navigation';
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     return {
         currentTimestamp: state.currentTimestamp,
         navigation: ownProps.navigation,

--- a/src/containers/NewSourceFeedContainer.ts
+++ b/src/containers/NewSourceFeedContainer.ts
@@ -5,17 +5,18 @@ import { Actions } from '../actions/Actions';
 import { Feed } from '../models/Feed';
 import { getFeedPosts } from '../selectors/selectors';
 import { mapDispatchToProps as defaultMapDispatchToProps } from '../containers/FeedContainer';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
-    const feed = ownProps.navigation.state.params.feed;
-    const addedFeed = state.feeds.find(value => value.feedUrl === feed.feedUrl);
-    const feeds = addedFeed != null ? [ addedFeed ] : [ feed ];
-    const feedName = ownProps.navigation.state.params.feed.name;
-    const posts = getFeedPosts(state, feed.feedUrl);
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
+    const navParamFeed = ownProps.navigation.getParam<Routes['NewsSourceFeed'], 'feed'>('feed');
+    const addedFeed = state.feeds.find(value => value.feedUrl === navParamFeed.feedUrl);
+    const feeds = addedFeed != null ? [ addedFeed ] : [ navParamFeed ];
+    const feedName = navParamFeed.name;
+    const posts = getFeedPosts(state, navParamFeed.feedUrl);
     return {
         onBack: () => ownProps.navigation.goBack(),
         navigation: ownProps.navigation,
-        feedUrl: feed.feedUrl,
+        feedUrl: navParamFeed.feedUrl,
         feedName,
         posts,
         feeds: feeds,

--- a/src/containers/NewSourceFeedContainer.ts
+++ b/src/containers/NewSourceFeedContainer.ts
@@ -8,7 +8,7 @@ import { mapDispatchToProps as defaultMapDispatchToProps } from '../containers/F
 import { TypedNavigation, Routes } from '../helpers/navigation';
 
 const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
-    const navParamFeed = ownProps.navigation.getParam<Routes['NewsSourceFeed'], 'feed'>('feed');
+    const navParamFeed = ownProps.navigation.getParam<'NewsSourceFeed', 'feed'>('feed');
     const addedFeed = state.feeds.find(value => value.feedUrl === navParamFeed.feedUrl);
     const feeds = addedFeed != null ? [ addedFeed ] : [ navParamFeed ];
     const feedName = navParamFeed.name;

--- a/src/containers/PostEditorContainer.ts
+++ b/src/containers/PostEditorContainer.ts
@@ -3,14 +3,14 @@ import { AppState } from '../reducers/AppState';
 import { AsyncActions, Actions } from '../actions/Actions';
 import { StateProps, DispatchProps, PostEditor } from '../components/PostEditor';
 import { Post } from '../models/Post';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
-    const post = ownProps.navigation.state.params ! = null ? ownProps.navigation.state.params.post : null;
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     return {
         name: state.author.name,
         avatar: state.author.image,
         navigation: ownProps.navigation,
-        draft: post != null ? post : state.draft,
+        draft: state.draft,
         gatewayAddress: state.settings.swarmGatewayAddress,
    };
 };

--- a/src/containers/RestoreContainer.ts
+++ b/src/containers/RestoreContainer.ts
@@ -2,8 +2,9 @@ import { connect } from 'react-redux';
 import { AppState } from '../reducers/AppState';
 import * as Actions from '../actions/Actions';
 import { StateProps, DispatchProps, Restore } from '../components/Restore';
+import { TypedNavigation } from '../helpers/navigation';
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     return {
         navigation: ownProps.navigation,
     };

--- a/src/containers/SettingsEditorContainer.ts
+++ b/src/containers/SettingsEditorContainer.ts
@@ -2,8 +2,9 @@ import { connect } from 'react-redux';
 import { AppState } from '../reducers/AppState';
 import { Actions } from '../actions/Actions';
 import { StateProps, DispatchProps, SettingsEditor } from '../components/SettingsEditor';
+import { TypedNavigation } from '../helpers/navigation';
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     return {
         navigation: ownProps.navigation,
         settings: state.settings,

--- a/src/containers/SettingsFeedViewContainer.ts
+++ b/src/containers/SettingsFeedViewContainer.ts
@@ -2,8 +2,9 @@ import { connect } from 'react-redux';
 import { AppState } from '../reducers/AppState';
 import { StateProps, FeedView } from '../components/FeedView';
 import { mapStateToProps as defaultStateToProps, mapDispatchToProps } from './FeedContainer';
+import { TypedNavigation } from '../helpers/navigation';
 
-export const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
+export const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     return {
         ...defaultStateToProps(state, ownProps),
         onBack: () => {

--- a/src/containers/WelcomeContainer.ts
+++ b/src/containers/WelcomeContainer.ts
@@ -3,8 +3,9 @@ import { StateProps, DispatchProps, Welcome } from '../components/Welcome';
 import { AppState } from '../reducers/AppState';
 import { AsyncActions, Actions } from '../actions/Actions';
 import { ImageData } from '../models/ImageData';
+import { TypedNavigation, Routes } from '../helpers/navigation';
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     return {
         navigation: ownProps.navigation,
         gatewayAddress: state.settings.swarmGatewayAddress,
@@ -16,14 +17,14 @@ const mapDispatchToProps = (dispatch: any): DispatchProps => {
         onStartDownloadFeeds: () => {
             dispatch(AsyncActions.downloadFollowedFeedPosts());
         },
-        onCreateUser: async (name: string, image: ImageData, navigation: any) => {
+        onCreateUser: async (name: string, image: ImageData, navigation: TypedNavigation) => {
             await dispatch(AsyncActions.chainActions([
                 Actions.updateAuthorName(name),
                 Actions.updateAuthorImage(image),
                 AsyncActions.createUserIdentity(),
                 AsyncActions.createOwnFeed(),
             ]));
-            navigation.navigate('Loading');
+            navigation.navigate<Routes, 'Loading'>('Loading', {});
         },
     };
 };

--- a/src/containers/WelcomeContainer.ts
+++ b/src/containers/WelcomeContainer.ts
@@ -24,7 +24,7 @@ const mapDispatchToProps = (dispatch: any): DispatchProps => {
                 AsyncActions.createUserIdentity(),
                 AsyncActions.createOwnFeed(),
             ]));
-            navigation.navigate<Routes, 'Loading'>('Loading', {});
+            navigation.navigate('Loading', {});
         },
     };
 };

--- a/src/containers/YourFeedContainer.ts
+++ b/src/containers/YourFeedContainer.ts
@@ -4,8 +4,9 @@ import { StateProps, DispatchProps, YourFeedView } from '../components/YourFeedV
 import { Post } from '../models/Post';
 import { Actions } from '../actions/Actions';
 import { Feed } from '../models/Feed';
+import { TypedNavigation } from '../helpers/navigation';
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     const posts = state.localPosts;
     const filteredPosts = posts;
 

--- a/src/helpers/navigation.ts
+++ b/src/helpers/navigation.ts
@@ -1,0 +1,69 @@
+import { ContentFilter } from '../models/ContentFilter';
+import { Feed } from '../models/Feed';
+import { SubCategory, NewsSource } from '../models/recommendation/NewsSource';
+import { LocalFeed } from '../social/api';
+
+export interface Routes {
+    App: {};
+    Loading: {};
+    Welcome: {};
+    Post: {};
+    Root: {};
+    ProfileTab: {};
+    PostTab: {};
+    FavoriteTab: {};
+    SettingsTab: {};
+    AllFeedTab: {};
+    BugReportView: {};
+    SwarmSettingsContainer: {};
+    FilterListEditorContainer: {};
+    Backup: {};
+    Restore: {};
+    BackupRestore: {};
+    LogViewer: {};
+    Debug: {};
+    FeedListViewerContainer: {
+        showExplore: boolean,
+        feeds?: Feed[],
+    };
+    Feed: {
+        feedUrl: string,
+        name: string,
+    };
+    FeedInfo: {
+        feed: Feed;
+    };
+    EditFilter: {
+        filter: ContentFilter,
+    };
+    FeedSettings: {
+        feed: LocalFeed,
+    };
+    FeedFromList: {
+        feedUrl: string,
+        name: string,
+    };
+    CategoriesContainer: {
+
+    };
+    SubCategoriesContainer: {
+        title: string,
+        subCategories: SubCategory[],
+    };
+    NewsSourceFeed: {
+        feed: Feed,
+    };
+    NewsSourceGridContainer: {
+        newsSources: NewsSource[],
+        subCategoryName: string,
+    };
+    YourTab: {};
+}
+
+export interface TypedNavigation {
+    goBack: (routeKey?: string | null) => boolean;
+    navigate: <T, K extends keyof T>(routeKey: K, params: T[K]) => boolean;
+    pop: (n?: number, params?: { immediate?: boolean }) => boolean;
+    getParam: <R, P extends keyof R>(param: P) => R[P];
+    setParams: <R>(newParams: R) => boolean;
+}

--- a/src/helpers/navigation.ts
+++ b/src/helpers/navigation.ts
@@ -61,9 +61,10 @@ export interface Routes {
 }
 
 export interface TypedNavigation {
-    goBack: (routeKey?: string | null) => boolean;
+    goBack: <K extends keyof Routes>(routeKey?: K | null) => boolean;
     navigate: <K extends keyof Routes>(routeKey: K, params: Routes[K]) => boolean;
     pop: (n?: number, params?: { immediate?: boolean }) => boolean;
-    getParam: <R, P extends keyof R>(param: P) => R[P];
-    setParams: <R>(newParams: R) => boolean;
+    getParam: <K extends keyof Routes, P extends keyof Routes[K]>(param: P) => K[P];
+    setParams: <K extends keyof Routes>(newParams: Routes[K]) => boolean;
 }
+//         navigation.setParams<Routes['FeedInfo']>({ feed: updatedFeed });

--- a/src/helpers/navigation.ts
+++ b/src/helpers/navigation.ts
@@ -62,7 +62,7 @@ export interface Routes {
 
 export interface TypedNavigation {
     goBack: (routeKey?: string | null) => boolean;
-    navigate: <T, K extends keyof T>(routeKey: K, params: T[K]) => boolean;
+    navigate: <K extends keyof Routes>(routeKey: K, params: Routes[K]) => boolean;
     pop: (n?: number, params?: { immediate?: boolean }) => boolean;
     getParam: <R, P extends keyof R>(param: P) => R[P];
     setParams: <R>(newParams: R) => boolean;

--- a/src/reducers/defaultData.ts
+++ b/src/reducers/defaultData.ts
@@ -73,8 +73,8 @@ export const defaultMetadata = {
 export const defaultFeeds: Feed[] = [
     {
         name: 'Felfele Assistant',
-        url: 'local/onboarding',
-        feedUrl: 'local/onboarding',
+        url: FELFELE_ASSISTANT_URL,
+        feedUrl: FELFELE_ASSISTANT_URL,
         favicon: '',
         followed: true,
     },

--- a/src/ui/screens/explore/CategoriesContainer.tsx
+++ b/src/ui/screens/explore/CategoriesContainer.tsx
@@ -2,8 +2,9 @@ import { connect } from 'react-redux';
 import { StateProps, CategoriesScreen } from './CategoriesScreen';
 import { AppState } from '../../../reducers/AppState';
 import { exploreData } from '../../../models/recommendation/NewsSource';
+import { TypedNavigation } from '../../../helpers/navigation';
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     return {
         categories: exploreData,
         navigation: ownProps.navigation,

--- a/src/ui/screens/explore/CategoriesScreen.tsx
+++ b/src/ui/screens/explore/CategoriesScreen.tsx
@@ -5,12 +5,13 @@ import { RegularText } from '../../misc/text';
 import { Category } from '../../../models/recommendation/NewsSource';
 import { NavigationHeader } from '../../../components/NavigationHeader';
 import { RowItem } from '../../misc/RowButton';
+import { TypedNavigation, Routes } from '../../../helpers/navigation';
 
 const CATEGORIES_LABEL = 'CATEGORIES';
 
 export interface StateProps {
     categories: Category[];
-    navigation: any;
+    navigation: TypedNavigation;
 }
 
 export interface DispatchProps { }
@@ -23,7 +24,7 @@ export const CategoriesScreen = (props: StateProps & DispatchProps) => {
                 title={category.name}
                 buttonStyle='navigate'
                 onPress={() => {
-                    props.navigation.navigate('SubCategoriesContainer', {
+                    props.navigation.navigate<Routes, 'SubCategoriesContainer'>('SubCategoriesContainer', {
                         title: category.name,
                         subCategories: category.subCategories,
                     });

--- a/src/ui/screens/explore/CategoriesScreen.tsx
+++ b/src/ui/screens/explore/CategoriesScreen.tsx
@@ -24,7 +24,7 @@ export const CategoriesScreen = (props: StateProps & DispatchProps) => {
                 title={category.name}
                 buttonStyle='navigate'
                 onPress={() => {
-                    props.navigation.navigate<Routes, 'SubCategoriesContainer'>('SubCategoriesContainer', {
+                    props.navigation.navigate('SubCategoriesContainer', {
                         title: category.name,
                         subCategories: category.subCategories,
                     });

--- a/src/ui/screens/explore/NewsSourceGridContainer.tsx
+++ b/src/ui/screens/explore/NewsSourceGridContainer.tsx
@@ -3,12 +3,16 @@ import { StateProps, NewsSourceGridScreen, DispatchProps } from './NewsSourceGri
 import { AppState } from '../../../reducers/AppState';
 import { Feed } from '../../../models/Feed';
 import { AsyncActions } from '../../../actions/Actions';
+import { TypedNavigation, Routes } from '../../../helpers/navigation';
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
+    const subCategoryName = ownProps.navigation.getParam<Routes['NewsSourceGridContainer'], 'subCategoryName'>('subCategoryName');
+    const newsSources = ownProps.navigation.getParam<Routes['NewsSourceGridContainer'], 'newsSources'>('newsSources');
+
     return {
-        subCategoryName: ownProps.navigation.state.params.subCategoryName,
+        subCategoryName: subCategoryName,
         gatewayAddress: state.settings.swarmGatewayAddress,
-        newsSource: ownProps.navigation.state.params.newsSources,
+        newsSource: newsSources,
         navigation: ownProps.navigation,
     };
 };

--- a/src/ui/screens/explore/NewsSourceGridContainer.tsx
+++ b/src/ui/screens/explore/NewsSourceGridContainer.tsx
@@ -6,8 +6,8 @@ import { AsyncActions } from '../../../actions/Actions';
 import { TypedNavigation, Routes } from '../../../helpers/navigation';
 
 const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
-    const subCategoryName = ownProps.navigation.getParam<Routes['NewsSourceGridContainer'], 'subCategoryName'>('subCategoryName');
-    const newsSources = ownProps.navigation.getParam<Routes['NewsSourceGridContainer'], 'newsSources'>('newsSources');
+    const subCategoryName = ownProps.navigation.getParam<'NewsSourceGridContainer', 'subCategoryName'>('subCategoryName');
+    const newsSources = ownProps.navigation.getParam<'NewsSourceGridContainer', 'newsSources'>('newsSources');
 
     return {
         subCategoryName: subCategoryName,

--- a/src/ui/screens/explore/NewsSourceGridScreen.tsx
+++ b/src/ui/screens/explore/NewsSourceGridScreen.tsx
@@ -53,7 +53,7 @@ export class NewsSourceGridScreen extends React.Component<StateProps & DispatchP
                                    imageUri={imageUri}
                                    onPress={() => {
                                        this.props.downloadPostsForNewsSource(item);
-                                       this.props.navigation.navigate<Routes, 'NewsSourceFeed'>('NewsSourceFeed', {
+                                       this.props.navigation.navigate('NewsSourceFeed', {
                                            feed: item,
                                        });
                                    }}

--- a/src/ui/screens/explore/NewsSourceGridScreen.tsx
+++ b/src/ui/screens/explore/NewsSourceGridScreen.tsx
@@ -9,12 +9,13 @@ import { NewsSource } from '../../../models/recommendation/NewsSource';
 import { RSSFeedManager } from '../../../RSSPostManager';
 import { Debug } from '../../../Debug';
 import { Feed } from '../../../models/Feed';
+import { TypedNavigation, Routes } from '../../../helpers/navigation';
 
 export interface StateProps {
     gatewayAddress: string;
     subCategoryName: string;
     newsSource: NewsSource[];
-    navigation: any;
+    navigation: TypedNavigation;
 }
 
 export interface DispatchProps {
@@ -52,7 +53,7 @@ export class NewsSourceGridScreen extends React.Component<StateProps & DispatchP
                                    imageUri={imageUri}
                                    onPress={() => {
                                        this.props.downloadPostsForNewsSource(item);
-                                       this.props.navigation.navigate('NewsSourceFeed', {
+                                       this.props.navigation.navigate<Routes, 'NewsSourceFeed'>('NewsSourceFeed', {
                                            feed: item,
                                        });
                                    }}

--- a/src/ui/screens/explore/SubCategoriesContainer.tsx
+++ b/src/ui/screens/explore/SubCategoriesContainer.tsx
@@ -4,8 +4,8 @@ import { AppState } from '../../../reducers/AppState';
 import { Routes } from '../../../helpers/navigation';
 
 const mapStateToProps = (state: AppState, ownProps: OwnProps): StateProps => {
-    const navParamTitle = ownProps.navigation.getParam<Routes['SubCategoriesContainer'], 'title'>('title');
-    const navParamSubCategories = ownProps.navigation.getParam<Routes['SubCategoriesContainer'], 'subCategories'>('subCategories');
+    const navParamTitle = ownProps.navigation.getParam<'SubCategoriesContainer', 'title'>('title');
+    const navParamSubCategories = ownProps.navigation.getParam<'SubCategoriesContainer', 'subCategories'>('subCategories');
     return {
         title: navParamTitle,
         subCategories: navParamSubCategories,

--- a/src/ui/screens/explore/SubCategoriesContainer.tsx
+++ b/src/ui/screens/explore/SubCategoriesContainer.tsx
@@ -1,11 +1,14 @@
 import { connect } from 'react-redux';
 import { StateProps, SubCategoriesScreen, OwnProps } from './SubCategoriesScreen';
 import { AppState } from '../../../reducers/AppState';
+import { Routes } from '../../../helpers/navigation';
 
 const mapStateToProps = (state: AppState, ownProps: OwnProps): StateProps => {
+    const navParamTitle = ownProps.navigation.getParam<Routes['SubCategoriesContainer'], 'title'>('title');
+    const navParamSubCategories = ownProps.navigation.getParam<Routes['SubCategoriesContainer'], 'subCategories'>('subCategories');
     return {
-        title: ownProps.navigation.state.params.title,
-        subCategories: ownProps.navigation.state.params.subCategories,
+        title: navParamTitle,
+        subCategories: navParamSubCategories,
         navigation: ownProps.navigation,
     };
 };

--- a/src/ui/screens/explore/SubCategoriesScreen.tsx
+++ b/src/ui/screens/explore/SubCategoriesScreen.tsx
@@ -28,7 +28,7 @@ export const SubCategoriesScreen = (props: StateProps & DispatchProps) => {
                 key={subCategory.name}
                 title={subCategory.name}
                 buttonStyle='navigate'
-                onPress={() => props.navigation.navigate<Routes, 'NewsSourceGridContainer'>('NewsSourceGridContainer', {
+                onPress={() => props.navigation.navigate('NewsSourceGridContainer', {
                     newsSources: subCategory.list,
                     subCategoryName: subCategory.name,
                 })}

--- a/src/ui/screens/explore/SubCategoriesScreen.tsx
+++ b/src/ui/screens/explore/SubCategoriesScreen.tsx
@@ -5,17 +5,18 @@ import { RegularText } from '../../misc/text';
 import { SubCategory } from '../../../models/recommendation/NewsSource';
 import { NavigationHeader } from '../../../components/NavigationHeader';
 import { RowItem } from '../../misc/RowButton';
+import { TypedNavigation, Routes } from '../../../helpers/navigation';
 
 const SUBCATEGORIES_LABEL = 'SUBCATEGORIES';
 
 export interface StateProps {
     subCategories: SubCategory[];
-    navigation: any;
+    navigation: TypedNavigation;
     title: string;
 }
 
 export interface OwnProps {
-    navigation: any;
+    navigation: TypedNavigation;
 }
 
 export interface DispatchProps { }
@@ -27,7 +28,7 @@ export const SubCategoriesScreen = (props: StateProps & DispatchProps) => {
                 key={subCategory.name}
                 title={subCategory.name}
                 buttonStyle='navigate'
-                onPress={() => props.navigation.navigate('NewsSourceGridContainer', {
+                onPress={() => props.navigation.navigate<Routes, 'NewsSourceGridContainer'>('NewsSourceGridContainer', {
                     newsSources: subCategory.list,
                     subCategoryName: subCategory.name,
                 })}

--- a/src/ui/screens/feed-settings/FeedSettingsContainer.ts
+++ b/src/ui/screens/feed-settings/FeedSettingsContainer.ts
@@ -1,11 +1,12 @@
 import { connect } from 'react-redux';
 import { StateProps, DispatchProps, FeedSettingsScreen } from './FeedSettingsScreen';
 import { AppState } from '../../../reducers/AppState';
-import { LocalFeed } from '../../../social/api';
 import { Actions } from '../../../actions/Actions';
+import { TypedNavigation, Routes } from '../../../helpers/navigation';
+import { Feed } from '../../../models/Feed';
 
-const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateProps => {
-    const paramFeed = ownProps.navigation.state.params.feed;
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
+    const paramFeed = ownProps.navigation.getParam<Routes['FeedSettings'], 'feed'>('feed');
     const feed = state.ownFeeds.find(ownFeed => ownFeed.feedUrl === paramFeed.feedUrl) || paramFeed;
     return {
         navigation: ownProps.navigation,
@@ -16,7 +17,7 @@ const mapStateToProps = (state: AppState, ownProps: { navigation: any }): StateP
 
 const mapDispatchToProps = (dispatch: any): DispatchProps => {
     return {
-        onChangeFeedSharing: (feed: LocalFeed, autoShare: boolean) => {
+        onChangeFeedSharing: (feed: Feed, autoShare: boolean) => {
             dispatch(Actions.updateOwnFeed({
                 feedUrl: feed.feedUrl,
                 autoShare,

--- a/src/ui/screens/feed-settings/FeedSettingsContainer.ts
+++ b/src/ui/screens/feed-settings/FeedSettingsContainer.ts
@@ -2,11 +2,11 @@ import { connect } from 'react-redux';
 import { StateProps, DispatchProps, FeedSettingsScreen } from './FeedSettingsScreen';
 import { AppState } from '../../../reducers/AppState';
 import { Actions } from '../../../actions/Actions';
-import { TypedNavigation, Routes } from '../../../helpers/navigation';
+import { TypedNavigation } from '../../../helpers/navigation';
 import { Feed } from '../../../models/Feed';
 
 const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
-    const paramFeed = ownProps.navigation.getParam<Routes['FeedSettings'], 'feed'>('feed');
+    const paramFeed = ownProps.navigation.getParam<'FeedSettings', 'feed'>('feed');
     const feed = state.ownFeeds.find(ownFeed => ownFeed.feedUrl === paramFeed.feedUrl) || paramFeed;
     return {
         navigation: ownProps.navigation,

--- a/src/ui/screens/feed-settings/FeedSettingsScreen.tsx
+++ b/src/ui/screens/feed-settings/FeedSettingsScreen.tsx
@@ -12,8 +12,8 @@ import { Colors } from '../../../styles';
 import { NavigationHeader } from '../../../components/NavigationHeader';
 import { RowItem } from '../../../ui/misc/RowButton';
 import { ReactNativeModelHelper } from '../../../models/ReactNativeModelHelper';
-import { LocalFeed } from '../../../social/api';
 import { TabBarPlaceholder } from '../../misc/TabBarPlaceholder';
+import { LocalFeed } from '../../../social/api';
 
 export interface StateProps {
     navigation: any;

--- a/test/components/CardTest.tsx
+++ b/test/components/CardTest.tsx
@@ -6,11 +6,20 @@ import { Author } from '../../src/models/Author';
 import TestRenderer from 'react-test-renderer';
 import { ReactNativeModelHelper } from '../../src/models/ReactNativeModelHelper';
 import { Debug } from '../../src/Debug';
+import { TypedNavigation } from '../../src/helpers/navigation';
 
 Debug.setDebug(true);
 jest.mock('../../src/models/ReactNativeModelHelper');
 jest.mock('../../src/components/CardMarkdown');
 jest.mock('../../src/ui/misc/Carousel');
+
+const mockNavigation: TypedNavigation = {
+    goBack: (routeKey?: string | null) => true,
+    navigate: (routeKey: any, params: any) => true,
+    pop: (n?: number, params?: { immediate?: boolean }) => true,
+    getParam: (param: any) => param.name,
+    setParams: (newParams: any) => true,
+};
 
 describe('card test', () => {
     const testAuthor: Author = {
@@ -56,7 +65,7 @@ describe('card test', () => {
             <Card
                 post={testPostWithoutImage}
                 isSelected={false}
-                navigate={(_) => {}}
+                navigation={mockNavigation}
                 onDeletePost={(_) => {}}
                 onSharePost={(_) => {}}
                 togglePostSelection={(_) => {}}
@@ -76,7 +85,7 @@ describe('card test', () => {
             <Card
                 post={testPostWithoutImage}
                 isSelected={true}
-                navigate={(_) => {}}
+                navigation={mockNavigation}
                 onDeletePost={(_) => {}}
                 onSharePost={(_) => {}}
                 togglePostSelection={(_) => {}}
@@ -96,7 +105,7 @@ describe('card test', () => {
             <Card
                 post={testPostWithImage}
                 isSelected={false}
-                navigate={(_) => {}}
+                navigation={mockNavigation}
                 onDeletePost={(_) => {}}
                 onSharePost={(_) => {}}
                 togglePostSelection={(_) => {}}
@@ -117,7 +126,7 @@ describe('card test', () => {
             <Card
                 post={testPostWithMultipleImages}
                 isSelected={false}
-                navigate={(_) => {}}
+                navigation={mockNavigation}
                 onDeletePost={(_) => {}}
                 onSharePost={(_) => {}}
                 togglePostSelection={(_) => {}}
@@ -138,7 +147,7 @@ describe('card test', () => {
             <Card
                 post={testPostWithImage}
                 isSelected={false}
-                navigate={(_) => {}}
+                navigation={mockNavigation}
                 onDeletePost={(_) => {}}
                 onSharePost={(_) => {}}
                 togglePostSelection={(_) => {}}


### PR DESCRIPTION
Changes proposed in this pull request:
- make custom typing for the navigation object, to cover our needs
- typings work well, we can send params when navigating to, and read them on arrival in a typed manner
Caveats:
- it is verbose
- the usage of route names in App.tsx (where we have our config) are not covered by type checking (yet?)