### PR TITLE
Fixed favorite feeds view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,7 +39,8 @@ import { CategoriesContainer } from './ui/screens/explore/CategoriesContainer';
 import { SubCategoriesContainer } from './ui/screens/explore/SubCategoriesContainer';
 import { NewsSourceGridContainer } from './ui/screens/explore/NewsSourceGridContainer';
 import { NewsSourceFeedContainer } from './containers/NewSourceFeedContainer';
-import { Routes, TypedNavigation } from './helpers/navigation';
+import { TypedNavigation } from './helpers/navigation';
+import { FavoriteListViewerContainer } from './containers/FavoriteListViewerContainer';
 
 YellowBox.ignoreWarnings([
     'Method `jumpToIndex` is deprecated.',
@@ -58,8 +59,8 @@ const favoriteTabScenes: NavigationRouteConfigMap = {
     Feed: {
         screen: FeedContainer,
     },
-    FeedListViewerContainer: {
-        screen: FeedListViewerContainer,
+    FavoriteListViewerContainer: {
+        screen: FavoriteListViewerContainer,
     },
     FeedFromList: {
         screen: SettingsFeedViewContainer,

--- a/src/components/AllFeedScreen.tsx
+++ b/src/components/AllFeedScreen.tsx
@@ -37,7 +37,7 @@ export class AllFeedScreen extends React.Component<Props> {
             >
                 {{
                     navigationHeader: <NavigationHeader
-                                    title='All feeds'
+                                    title='Home'
                                     rightButton1={{
                                         onPress: () => this.props.navigation.navigate('FeedListViewerContainer', {
                                             showExplore: true,

--- a/src/components/FavoritesFeedView.tsx
+++ b/src/components/FavoritesFeedView.tsx
@@ -38,9 +38,8 @@ export const FavoritesFeedView = (props: Props) => {
                         title='Favorites'
                         rightButton1={{
                             onPress: () => props.navigation.navigate(
-                                'FeedListViewerContainer', {
+                                'FavoriteListViewerContainer', {
                                     feeds: props.feeds,
-                                    showExplore: false,
                                 }
                             ),
                             label: <Icon

--- a/src/components/FeedListEditor.tsx
+++ b/src/components/FeedListEditor.tsx
@@ -20,11 +20,14 @@ export interface DispatchProps {
     openExplore: () => void;
 }
 
+export interface FeedSection {
+    title?: string;
+    data: Feed[];
+}
+
 export interface StateProps {
     navigation: TypedNavigation;
-    ownFeeds: Feed[];
-    followedFeeds: Feed[];
-    knownFeeds: Feed[];
+    sections: FeedSection[];
     gatewayAddress: string;
     title: string;
     showExplore: boolean;
@@ -34,25 +37,6 @@ export class FeedGrid extends React.PureComponent<DispatchProps & StateProps & {
     public render() {
         const itemDimension = getGridCardSize();
         const modelHelper = new ReactNativeModelHelper(this.props.gatewayAddress);
-        const sections: Array<{ title: string, data: Feed[] }> = [];
-        if (this.props.ownFeeds.length > 0) {
-            sections.push({
-                title: `Your feeds ${this.props.ownFeeds.length}`,
-                data: this.props.ownFeeds,
-            });
-        }
-        if (this.props.followedFeeds.length > 0) {
-            sections.push({
-                title: `Public feeds you follow  ${this.props.followedFeeds.length}`,
-                data: this.props.followedFeeds,
-            });
-        }
-        if (this.props.knownFeeds.length > 0) {
-            sections.push({
-                title: `Other feeds  ${this.props.knownFeeds.length}`,
-                data: this.props.knownFeeds,
-            });
-        }
         return (
             <View style={{ backgroundColor: Colors.BACKGROUND_COLOR, flex: 1 }}>
                 {this.props.children}
@@ -61,7 +45,7 @@ export class FeedGrid extends React.PureComponent<DispatchProps & StateProps & {
                     spacing={10}
                     fixed={true}
                     itemDimension={itemDimension}
-                    sections={sections}
+                    sections={this.props.sections}
                     renderItem={({ item }: any) => {
                         const image: ImageData = item.authorImage != null
                             ? item.authorImage
@@ -79,7 +63,7 @@ export class FeedGrid extends React.PureComponent<DispatchProps & StateProps & {
                             />
                         );
                     }}
-                    renderSectionHeader={({ section }) => (
+                    renderSectionHeader={({ section }) => ( section.title &&
                         <MediumText style={styles.sectionHeader}>{section.title}</MediumText>
                     )}
                     // @ts-ignore - SuperGridSectionList is passing props to internal SectionList, typings is missing

--- a/src/containers/FavoriteListViewerContainer.ts
+++ b/src/containers/FavoriteListViewerContainer.ts
@@ -1,0 +1,38 @@
+import { connect } from 'react-redux';
+
+import { AppState } from '../reducers/AppState';
+import { StateProps, DispatchProps, FeedListEditor, FeedSection } from '../components/FeedListEditor';
+import { Feed } from '../models/Feed';
+import { TypedNavigation } from '../helpers/navigation';
+
+const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation, showExplore: boolean }): StateProps => {
+    const navParamFeeds = ownProps.navigation.getParam<'FavoriteListViewerContainer', 'feeds'>('feeds');
+
+    const sections: FeedSection[] = [{
+        data: navParamFeeds,
+    }];
+
+    return {
+        sections,
+        navigation: ownProps.navigation,
+        gatewayAddress: state.settings.swarmGatewayAddress,
+        title: 'Favorite feeds',
+        showExplore: false,
+    };
+};
+
+export const mapDispatchToProps = (dispatch: any, ownProps: { navigation: TypedNavigation }): DispatchProps => {
+    return {
+        openExplore: () => {
+            ownProps.navigation.navigate('CategoriesContainer', {});
+        },
+        onPressFeed: (feed: Feed) => {
+            ownProps.navigation.navigate('FeedFromList', {
+                feedUrl: feed.feedUrl,
+                name: feed.name,
+            });
+        },
+    };
+};
+
+export const FavoriteListViewerContainer = connect(mapStateToProps, mapDispatchToProps)(FeedListEditor);

--- a/src/helpers/navigation.ts
+++ b/src/helpers/navigation.ts
@@ -26,6 +26,9 @@ export interface Routes {
         showExplore: boolean,
         feeds?: Feed[],
     };
+    FavoriteListViewerContainer: {
+        feeds: Feed[],
+    };
     Feed: {
         feedUrl: string,
         name: string,


### PR DESCRIPTION
Fixes #256.

Changes proposed in this pull request:
- Changed favorite feeds screen title to 'Favorite feeds'
- Made the `FeedListEditor` component more parametrizable with `sections` property
- Added `FeedSection` helper type with optional `title` property
- Changed all feeds screen title to 'Home'
