### PR TITLE
Fix double post 267

### DIFF
--- a/src/actions/Actions.ts
+++ b/src/actions/Actions.ts
@@ -173,7 +173,8 @@ export const AsyncActions = {
             const notUpdatedPosts = previousPosts.filter(post => post.author != null && !uniqueAuthors.has(post.author.uri));
             const allPosts = notUpdatedPosts.concat(downloadedPosts);
             const sortedPosts = allPosts.sort((a, b) => b.createdAt - a.createdAt);
-            const posts = sortedPosts.map((post, index) => ({...post, _id: index}));
+            const startId = Date.now();
+            const posts = sortedPosts.map((post, index) => ({...post, _id: startId + index}));
 
             dispatch(Actions.updateRssPosts(posts));
         };

--- a/src/components/PostEditor.tsx
+++ b/src/components/PostEditor.tsx
@@ -44,6 +44,7 @@ type Props = StateProps & DispatchProps;
 
 interface State {
     post: Post;
+    isSending: boolean;
 }
 
 export class PostEditor extends React.Component<Props, State> {
@@ -54,15 +55,17 @@ export class PostEditor extends React.Component<Props, State> {
         super(props);
         this.state = {
             post: this.getPostFromDraft(this.props.draft),
+            isSending: false,
         };
         this.modelHelper = new ReactNativeModelHelper(this.props.gatewayAddress);
     }
 
     public render() {
         const isPostEmpty = this.isPostEmpty();
-        const sendIconColor = isPostEmpty ? Colors.GRAY : Colors.BRAND_PURPLE;
+        const isSendEnabled = !isPostEmpty && !this.state.isSending;
+        const sendIconColor = isSendEnabled ? Colors.BRAND_PURPLE : Colors.GRAY;
         const sendIcon = <Icon name='send' size={20} color={sendIconColor} />;
-        const sendButtonOnPress = isPostEmpty ? () => {} : this.onPressSubmit;
+        const sendButtonOnPress = isSendEnabled ? this.onPressSubmit : () => {};
         return (
             <SafeAreaView style={styles.container}>
                 <KeyboardAvoidingView
@@ -230,9 +233,13 @@ export class PostEditor extends React.Component<Props, State> {
 
     private sendUpdate = () => {
         this.setState({
+            isSending: true,
+        });
+        const markdownText = markdownEscape(this.state.post.text);
+        this.setState({
            post: {
             ...this.state.post,
-            text: markdownEscape(this.state.post.text),
+            text: markdownText,
            },
         }, () => {
             Debug.log(this.state.post);


### PR DESCRIPTION
Fixes #267 .

Changes proposed in this pull request:
- Added a workaround to avoid `_id` collusion (this is for both platforms)
- Disabled the send button in the post editor after sending. It seems that the `markdownEscape` function may take significant time on android
