### PR TITLE
Fix post autoshare 268

### DIFF
--- a/src/social/serialization.ts
+++ b/src/social/serialization.ts
@@ -1,3 +1,5 @@
+import { Debug } from '../Debug';
+
 const keyBlacklist = new Set<string>()
     .add('localPath')
     .add('privateKey')
@@ -5,8 +7,18 @@ const keyBlacklist = new Set<string>()
     ;
 
 export const serialize = (data: any): string => {
-    return JSON.stringify(data, (key, value) =>
-        (key.startsWith('_') || keyBlacklist.has(key)) ? undefined : value);
+    try {
+        const serializedData = JSON.stringify(data, (key, value) => {
+            return (typeof key === 'string' && (key.startsWith('_') || keyBlacklist.has(key)))
+                ? undefined
+                : value
+            ;
+        });
+        return serializedData;
+    } catch (e) {
+        Debug.log('serialize', 'e', e, 'data', data);
+        throw e;
+    }
 };
 
 export const deserialize = (data: string): any => {

--- a/test/social/serializationTest.ts
+++ b/test/social/serializationTest.ts
@@ -63,3 +63,11 @@ test('Serializing undefined key should work', () => {
 
     expect(result).toBe(expected);
 });
+
+test('Serializing arrays should work', () => {
+    const input = [0, 1, 2];
+    const expected = `[0,1,2]`;
+    const result = serialize(input);
+
+    expect(result).toBe(expected);
+});

--- a/test/social/serializationTest.ts
+++ b/test/social/serializationTest.ts
@@ -47,3 +47,19 @@ test('Serializing should skip blacklisted names but work with normal', () => {
 
     expect(result).toBe(expected);
 });
+
+test('Serializing undefined should work', () => {
+    const input = undefined;
+    const expected = undefined;
+    const result = serialize(input);
+
+    expect(result).toBe(expected);
+});
+
+test('Serializing undefined key should work', () => {
+    const input = {undefined};
+    const expected = `{}`;
+    const result = serialize(input);
+
+    expect(result).toBe(expected);
+});


### PR DESCRIPTION
Fixes #268 .

Changes proposed in this pull request:
- On android `JSON.stringify` behaves differently than V8 and JSC when serializing arrays: it calls the replacer with `key` as number instead of string. I added a check and extra logging in case we catch other differences.
