### PR TITLE
Fixed feed name and image change when changing profile name and image

### DIFF
--- a/src/actions/Actions.ts
+++ b/src/actions/Actions.ts
@@ -74,6 +74,10 @@ const InternalActions = {
         createAction(ActionTypes.UPDATE_FEED_FAVICON, {feed, favicon}),
     appStateSet: (appState: AppState) =>
         createAction(ActionTypes.APP_STATE_SET, { appState }),
+    updateAuthorName: (name: string) =>
+        createAction(ActionTypes.UPDATE_AUTHOR_NAME, { name }),
+    updateAuthorImage: (image: ImageData) =>
+        createAction(ActionTypes.UPDATE_AUTHOR_IMAGE, { image }),
 };
 
 export const Actions = {
@@ -107,10 +111,6 @@ export const Actions = {
         createAction(ActionTypes.ADD_DRAFT, { draft }),
     removeDraft: () =>
         createAction(ActionTypes.REMOVE_DRAFT),
-    updateAuthorName: (name: string) =>
-        createAction(ActionTypes.UPDATE_AUTHOR_NAME, { name }),
-    updateAuthorImage: (image: ImageData) =>
-        createAction(ActionTypes.UPDATE_AUTHOR_IMAGE, { image }),
     appStateReset: () =>
         createAction(ActionTypes.APP_STATE_RESET),
     changeSettingSaveToCameraRoll: (value: boolean) =>
@@ -353,7 +353,7 @@ export const AsyncActions = {
                         ...getState().author.image,
                         uri: storageSyncUpdate.recentPostFeed.authorImage.uri,
                     };
-                    dispatch(Actions.updateAuthorImage(authorImage));
+                    dispatch(InternalActions.updateAuthorImage(authorImage));
                 }
 
                 // Re-check if there were an update to the command log during syncing
@@ -416,6 +416,31 @@ export const AsyncActions = {
             const appState = await getAppStateFromSerialized(serializedAppState);
             const currentVersionAppState = await migrateAppStateToCurrentVersion(appState);
             dispatch(InternalActions.appStateSet(currentVersionAppState));
+        };
+    },
+    updateProfileName: (name: string): Thunk => {
+        return async (dispatch, getState) => {
+            dispatch(InternalActions.updateAuthorName(name));
+            if (getState().ownFeeds.length > 0) {
+                const ownFeed = getState().ownFeeds[0];
+                dispatch(Actions.updateOwnFeed({
+                    feedUrl: ownFeed.feedUrl,
+                    name,
+                }));
+            }
+        };
+    },
+    updateProfileImage: (image: ImageData): Thunk => {
+        return async (dispatch, getState) => {
+            dispatch(InternalActions.updateAuthorImage(image));
+            if (getState().ownFeeds.length > 0) {
+                const ownFeed = getState().ownFeeds[0];
+                dispatch(Actions.updateOwnFeed({
+                    feedUrl: ownFeed.feedUrl,
+                    authorImage: image,
+                    favicon: undefined,
+                }));
+            }
         };
     },
 };

--- a/src/components/IdentitySettings.tsx
+++ b/src/components/IdentitySettings.tsx
@@ -20,10 +20,10 @@ import MaterialCommunityIcon from 'react-native-vector-icons/MaterialCommunityIc
 import { SimpleTextInput } from './SimpleTextInput';
 import { Author } from '../models/Author';
 import { ImageData } from '../models/ImageData';
+import { Feed } from '../models/Feed';
 import { AsyncImagePicker } from '../AsyncImagePicker';
 import { Colors } from '../styles';
 import { NavigationHeader } from './NavigationHeader';
-import { Feed } from '../models/Feed';
 import { Debug } from '../Debug';
 import { ReactNativeModelHelper } from '../models/ReactNativeModelHelper';
 import { RowItem } from '../ui/misc/RowButton';
@@ -32,18 +32,19 @@ import { TabBarPlaceholder } from '../ui/misc/TabBarPlaceholder';
 import { defaultImages } from '../defaultImages';
 import { DEFAULT_AUTHOR_NAME } from '../reducers/defaultData';
 import { TypedNavigation } from '../helpers/navigation';
+import { LocalFeed } from '../social/api';
 
 const defaultUserImage = defaultImages.userCircle;
 
 export interface DispatchProps {
-    onUpdateAuthor: (text: string) => void;
-    onUpdatePicture: (image: ImageData) => void;
+    onUpdateAuthor: (text: string, ownFeed?: LocalFeed) => void;
+    onUpdatePicture: (image: ImageData, ownFeed?: LocalFeed) => void;
     onChangeText?: (text: string) => void;
 }
 
 export interface StateProps {
     author: Author;
-    ownFeed?: Feed;
+    ownFeed?: LocalFeed;
     navigation: TypedNavigation;
     gatewayAddress: string;
 }
@@ -105,7 +106,7 @@ export const IdentitySettings = (props: DispatchProps & StateProps) => {
                 >
                     <TouchableOpacity
                         onPress={async () => {
-                            await openImagePicker(props.onUpdatePicture);
+                            await openImagePicker(props.onUpdatePicture, props.ownFeed);
                         }}
                         style={styles.imagePickerContainer}
                     >
@@ -129,8 +130,8 @@ export const IdentitySettings = (props: DispatchProps & StateProps) => {
                         returnKeyType={'done'}
                         onSubmitEditing={(name) =>
                             name === ''
-                            ? props.onUpdateAuthor(NAME_PLACEHOLDER)
-                            : props.onUpdateAuthor(name)
+                            ? props.onUpdateAuthor(NAME_PLACEHOLDER, props.ownFeed)
+                            : props.onUpdateAuthor(name, props.ownFeed)
                         }
                     />
                     <RegularText style={styles.tooltip}>{ACTIVITY_LABEL}</RegularText>
@@ -156,10 +157,10 @@ export const IdentitySettings = (props: DispatchProps & StateProps) => {
     );
 };
 
-const openImagePicker = async (onUpdatePicture: (imageData: ImageData) => void) => {
+const openImagePicker = async (onUpdatePicture: (imageData: ImageData, ownFeed?: LocalFeed) => void, ownFeed?: LocalFeed) => {
     const imageData = await AsyncImagePicker.launchImageLibrary();
     if (imageData != null) {
-        onUpdatePicture(imageData);
+        onUpdatePicture(imageData, ownFeed);
     }
 };
 

--- a/src/components/IdentitySettings.tsx
+++ b/src/components/IdentitySettings.tsx
@@ -37,8 +37,8 @@ import { LocalFeed } from '../social/api';
 const defaultUserImage = defaultImages.userCircle;
 
 export interface DispatchProps {
-    onUpdateAuthor: (text: string, ownFeed?: LocalFeed) => void;
-    onUpdatePicture: (image: ImageData, ownFeed?: LocalFeed) => void;
+    onUpdateAuthor: (text: string) => void;
+    onUpdatePicture: (image: ImageData) => void;
     onChangeText?: (text: string) => void;
 }
 
@@ -106,7 +106,7 @@ export const IdentitySettings = (props: DispatchProps & StateProps) => {
                 >
                     <TouchableOpacity
                         onPress={async () => {
-                            await openImagePicker(props.onUpdatePicture, props.ownFeed);
+                            await openImagePicker(props.onUpdatePicture);
                         }}
                         style={styles.imagePickerContainer}
                     >
@@ -130,8 +130,8 @@ export const IdentitySettings = (props: DispatchProps & StateProps) => {
                         returnKeyType={'done'}
                         onSubmitEditing={(name) =>
                             name === ''
-                            ? props.onUpdateAuthor(NAME_PLACEHOLDER, props.ownFeed)
-                            : props.onUpdateAuthor(name, props.ownFeed)
+                            ? props.onUpdateAuthor(NAME_PLACEHOLDER)
+                            : props.onUpdateAuthor(name)
                         }
                     />
                     <RegularText style={styles.tooltip}>{ACTIVITY_LABEL}</RegularText>
@@ -157,10 +157,10 @@ export const IdentitySettings = (props: DispatchProps & StateProps) => {
     );
 };
 
-const openImagePicker = async (onUpdatePicture: (imageData: ImageData, ownFeed?: LocalFeed) => void, ownFeed?: LocalFeed) => {
+const openImagePicker = async (onUpdatePicture: (imageData: ImageData) => void) => {
     const imageData = await AsyncImagePicker.launchImageLibrary();
     if (imageData != null) {
-        onUpdatePicture(imageData, ownFeed);
+        onUpdatePicture(imageData);
     }
 };
 

--- a/src/containers/IdentitySettingsContainer.ts
+++ b/src/containers/IdentitySettingsContainer.ts
@@ -4,7 +4,6 @@ import { AsyncActions } from '../actions/Actions';
 import { StateProps, DispatchProps, IdentitySettings } from '../components/IdentitySettings';
 import { ImageData} from '../models/ImageData';
 import { TypedNavigation } from '../helpers/navigation';
-import { LocalFeed } from '../social/api';
 
 export const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     const ownFeed = state.ownFeeds.length > 0
@@ -23,7 +22,7 @@ const mapDispatchToProps = (dispatch: any): DispatchProps => {
         onUpdateAuthor: (text: string) => {
             dispatch(AsyncActions.updateProfileName(text));
         },
-        onUpdatePicture: (image: ImageData, ownFeed?: LocalFeed) => {
+        onUpdatePicture: (image: ImageData) => {
             dispatch(AsyncActions.updateProfileImage(image));
         },
     };

--- a/src/containers/IdentitySettingsContainer.ts
+++ b/src/containers/IdentitySettingsContainer.ts
@@ -4,6 +4,7 @@ import { Actions } from '../actions/Actions';
 import { StateProps, DispatchProps, IdentitySettings } from '../components/IdentitySettings';
 import { ImageData} from '../models/ImageData';
 import { TypedNavigation } from '../helpers/navigation';
+import { LocalFeed } from '../social/api';
 
 export const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     const ownFeed = state.ownFeeds.length > 0
@@ -19,11 +20,24 @@ export const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNa
 
 const mapDispatchToProps = (dispatch: any): DispatchProps => {
     return {
-        onUpdateAuthor: (text: string) => {
+        onUpdateAuthor: (text: string, ownFeed?: LocalFeed) => {
             dispatch(Actions.updateAuthorName(text));
+            if (ownFeed != null) {
+                dispatch(Actions.updateOwnFeed({
+                    feedUrl: ownFeed.feedUrl,
+                    name: text,
+                }));
+            }
         },
-        onUpdatePicture: (image: ImageData) => {
+        onUpdatePicture: (image: ImageData, ownFeed?: LocalFeed) => {
             dispatch(Actions.updateAuthorImage(image));
+            if (ownFeed != null) {
+                dispatch(Actions.updateOwnFeed({
+                    feedUrl: ownFeed.feedUrl,
+                    authorImage: image,
+                    favicon: undefined,
+                }));
+            }
         },
     };
 };

--- a/src/containers/IdentitySettingsContainer.ts
+++ b/src/containers/IdentitySettingsContainer.ts
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { AppState } from '../reducers/AppState';
-import { Actions } from '../actions/Actions';
+import { AsyncActions } from '../actions/Actions';
 import { StateProps, DispatchProps, IdentitySettings } from '../components/IdentitySettings';
 import { ImageData} from '../models/ImageData';
 import { TypedNavigation } from '../helpers/navigation';
@@ -20,24 +20,11 @@ export const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNa
 
 const mapDispatchToProps = (dispatch: any): DispatchProps => {
     return {
-        onUpdateAuthor: (text: string, ownFeed?: LocalFeed) => {
-            dispatch(Actions.updateAuthorName(text));
-            if (ownFeed != null) {
-                dispatch(Actions.updateOwnFeed({
-                    feedUrl: ownFeed.feedUrl,
-                    name: text,
-                }));
-            }
+        onUpdateAuthor: (text: string) => {
+            dispatch(AsyncActions.updateProfileName(text));
         },
         onUpdatePicture: (image: ImageData, ownFeed?: LocalFeed) => {
-            dispatch(Actions.updateAuthorImage(image));
-            if (ownFeed != null) {
-                dispatch(Actions.updateOwnFeed({
-                    feedUrl: ownFeed.feedUrl,
-                    authorImage: image,
-                    favicon: undefined,
-                }));
-            }
+            dispatch(AsyncActions.updateProfileImage(image));
         },
     };
 };

--- a/src/containers/WelcomeContainer.ts
+++ b/src/containers/WelcomeContainer.ts
@@ -19,8 +19,8 @@ const mapDispatchToProps = (dispatch: any): DispatchProps => {
         },
         onCreateUser: async (name: string, image: ImageData, navigation: TypedNavigation) => {
             await dispatch(AsyncActions.chainActions([
-                Actions.updateAuthorName(name),
-                Actions.updateAuthorImage(image),
+                AsyncActions.updateProfileName(name),
+                AsyncActions.updateProfileImage(image),
                 AsyncActions.createUserIdentity(),
                 AsyncActions.createOwnFeed(),
             ]));


### PR DESCRIPTION
Fixes #272 .

Changes proposed in this pull request:
- When updating the name or the image from the `IdentitySettings`(which should ideally be called `ProfileSettings`) it also updates the localFeed (if any).
