### PR TITLE
Fix buffer deprecation warning 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,7 @@ YellowBox.ignoreWarnings([
     'Method `jumpToIndex` is deprecated.',
     'unknown call: "relay:check"',
 ]);
-Debug.setDebug(true);
+Debug.setDebugMode(true);
 Debug.addLogger(appendToLog);
 setCustomText(defaultTextProps);
 

--- a/src/Debug.ts
+++ b/src/Debug.ts
@@ -1,8 +1,9 @@
 type Logger = (s: string) => void;
 
 export class Debug {
-    public static setDebug(isDebug: boolean) {
-        Debug.isDebug = isDebug;
+    public static isDebugMode = false;
+    public static setDebugMode(isDebug: boolean) {
+        Debug.isDebugMode = isDebug;
     }
 
     public static setMaxLength(length: number) {
@@ -10,7 +11,7 @@ export class Debug {
     }
 
     public static log(...args: any[]) {
-        if (__DEV__ && Debug.isDebug) {
+        if (__DEV__ && Debug.isDebugMode) {
             // tslint:disable-next-line:no-console
             console.log.call(console, ...args);
         }
@@ -30,12 +31,11 @@ export class Debug {
         Debug.loggers.push(logger);
     }
 
-    private static isDebug = false;
     private static maxLength = 1000;
     private static loggers: Logger[] = [];
 
     private static fullLog(...args: any[]) {
-        if (Debug.isDebug) {
+        if (Debug.isDebugMode) {
             const logLine = args.map(arg => '' + arg).join(' ');
             for (const logger of Debug.loggers) {
                 logger(logLine);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,14 +27,14 @@ global.FormData = FormData;
 
 // tslint:disable-next-line:no-console
 let output = console.log;
-Debug.setDebug(false);
+Debug.setDebugMode(false);
 let swarmGateway = process.env.SWARM_GATEWAY || Swarm.defaultGateway;
 const jsonPrettyPrint = (obj: any) => JSON.stringify(obj, null, 4);
 
 const definitions =
     addOption('-q, --quiet', 'quiet mode', () => output = () => {})
     .
-    addOption('-v, --verbose', 'verbose mode', () => Debug.setDebug(true))
+    addOption('-v, --verbose', 'verbose mode', () => Debug.setDebugMode(true))
     .
     addCommand('version', 'Print app version', () => output(Version))
     .
@@ -45,9 +45,13 @@ const definitions =
             };
             if (testName == null) {
                 for (const test of Object.keys(allTests)) {
-                    output('\nRunning test: ', test);
+                    output('Running test:', test);
                     await allTests[test]();
+                    if (Debug.isDebugMode) {
+                        output('Finished test:', test, '\n\n');
+                    }
                 }
+                output(`${Object.keys(allTests).length} tests passed succesfully`);
             } else {
                 const test = allTests[testName];
                 output('\nRunning test: ', testName);

--- a/src/swarm/Swarm.ts
+++ b/src/swarm/Swarm.ts
@@ -420,7 +420,7 @@ function publicKeyToAddress(pubKey: any) {
 
 export const signDigest = (digest: number[], identity: PrivateIdentity) => {
     const curve = new ec('secp256k1');
-    const keyPair = curve.keyFromPrivate(new Buffer(identity.privateKey.substring(2), 'hex'));
+    const keyPair = curve.keyFromPrivate(Buffer.from(identity.privateKey.substring(2), 'hex'));
     const sigRaw = curve.sign(digest, keyPair, { canonical: true, pers: undefined });
     const partialSignature = sigRaw.r.toArray().concat(sigRaw.s.toArray());
     if (sigRaw.recoveryParam != null) {

--- a/test/components/CardTest.tsx
+++ b/test/components/CardTest.tsx
@@ -8,7 +8,7 @@ import { ReactNativeModelHelper } from '../../src/models/ReactNativeModelHelper'
 import { Debug } from '../../src/Debug';
 import { TypedNavigation } from '../../src/helpers/navigation';
 
-Debug.setDebug(true);
+Debug.setDebugMode(true);
 jest.mock('../../src/models/ReactNativeModelHelper');
 jest.mock('../../src/components/CardMarkdown');
 jest.mock('../../src/ui/misc/Carousel');

--- a/test/social/apiTest.ts
+++ b/test/social/apiTest.ts
@@ -14,7 +14,7 @@ import {
 } from '../../src/social/apiTest';
 import { Debug } from '../../src/Debug';
 
-beforeEach(() => Debug.setDebug(false));
+beforeEach(() => Debug.setDebugMode(false));
 
 test('Test sharing post', async () => testSharePost());
 test('Test sharing multiple posts', async () => testSharePosts());

--- a/test/social/syncTest.ts
+++ b/test/social/syncTest.ts
@@ -6,7 +6,7 @@ import { Debug } from '../../src/Debug';
 let localSwarmStorage: PostCommandLogStorage;
 const source = 'storage';
 
-beforeAll(() => Debug.setDebug(false));
+beforeAll(() => Debug.setDebugMode(false));
 beforeEach(() => localSwarmStorage = makeLocalSwarmStorage());
 
 test('Test sharing posts to storage', async () =>


### PR DESCRIPTION
Fixes #291

Changes proposed in this pull request:
- Changed `new Buffer` to `Buffer.from` 
- Renamed the `isDebug` variable to `isDebugMode` and made it accessible externally
- Changed CLI integration test output for readability
