### PR TITLE
Fixed stuck spinner

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,10 +1,23 @@
+const clearTimeoutIfSet = (timeout: any) => {
+    if (timeout != null) {
+        clearTimeout(timeout);
+    }
+};
+
 export class Utils {
     public static async timeout<T>(ms: number, promise: Promise<T>): Promise<T> {
         return new Promise<T>((resolve, reject) => {
-            if (ms > 0) {
-                setTimeout(() => reject(new Error('timeout')), ms);
-            }
-            promise.then(resolve, reject);
+            const timeout = ms > 0
+                ? setTimeout(() => reject(new Error('timeout')), ms)
+                : undefined
+            ;
+            promise.then((value) => {
+                clearTimeoutIfSet(timeout);
+                resolve(value);
+            }, (reason) => {
+                clearTimeoutIfSet(timeout);
+                reject(reason);
+            });
         });
     }
 

--- a/src/swarm-social/swarmStorage.ts
+++ b/src/swarm-social/swarmStorage.ts
@@ -382,8 +382,24 @@ export const downloadRecentPostFeed = async (swarm: Swarm.ReadableApi, url: stri
     }
 };
 
+const safeDownloadRecentPostFeed = async (swarm: Swarm.ReadableApi, feedUrl: string): Promise<RecentPostFeed> => {
+    try {
+        const recentPostFeed = await downloadRecentPostFeed(swarm, feedUrl);
+        return recentPostFeed;
+    } catch (e) {
+        return {
+            posts: [],
+            authorImage: {},
+            name: '',
+            url: '',
+            feedUrl: '',
+            favicon: '',
+        };
+    }
+};
+
 export const loadRecentPosts = async (swarm: Swarm.ReadableApi, postFeeds: Feed[]): Promise<PublicPost[]> => {
-    const loadFeedPromises = postFeeds.map(feed => downloadRecentPostFeed(swarm, feed.feedUrl));
+    const loadFeedPromises = postFeeds.map(feed => safeDownloadRecentPostFeed(swarm, feed.feedUrl));
     const feeds = await Promise.all(loadFeedPromises);
     let posts: PublicPost[] = [];
     for (const feed of feeds) {


### PR DESCRIPTION
Fixes #295 .

Changes proposed in this pull request:
- The timeout helper properly clears the timeout values
- Added a `safeDownloadRecentPostFeed` helper that returns an empty `RecentPostFeed` if the feed is not found instead of a timeout exception
