### PR TITLE
Change header style

### DIFF
--- a/src/components/AllFeedScreen.tsx
+++ b/src/components/AllFeedScreen.tsx
@@ -4,7 +4,7 @@ import { Feed } from '../models/Feed';
 import { Post } from '../models/Post';
 import { NavigationHeader } from './NavigationHeader';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
-import { Colors } from '../styles';
+import { ComponentColors } from '../styles';
 import { ImageData } from '../models/ImageData';
 import { FeedHeader } from './FeedHeader';
 import { ReactNativeModelHelper } from '../models/ReactNativeModelHelper';
@@ -45,7 +45,7 @@ export class AllFeedScreen extends React.Component<Props> {
                                         label: <Icon
                                             name={'view-grid'}
                                             size={20}
-                                            color={Colors.NAVIGATION_BUTTON_COLOR}
+                                            color={ComponentColors.NAVIGATION_BUTTON_COLOR}
                                         />,
                                     }}
                                     onPressTitle={this.ref && this.ref.scrollToTop}

--- a/src/components/AllFeedScreen.tsx
+++ b/src/components/AllFeedScreen.tsx
@@ -45,7 +45,7 @@ export class AllFeedScreen extends React.Component<Props> {
                                         label: <Icon
                                             name={'view-grid'}
                                             size={20}
-                                            color={Colors.DARK_GRAY}
+                                            color={Colors.NAVIGATION_BUTTON_COLOR}
                                         />,
                                     }}
                                     onPressTitle={this.ref && this.ref.scrollToTop}

--- a/src/components/AllFeedScreen.tsx
+++ b/src/components/AllFeedScreen.tsx
@@ -4,6 +4,7 @@ import { Feed } from '../models/Feed';
 import { Post } from '../models/Post';
 import { NavigationHeader } from './NavigationHeader';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import { ComponentColors } from '../styles';
 import { ImageData } from '../models/ImageData';
 import { FeedHeader } from './FeedHeader';
@@ -36,20 +37,36 @@ export class AllFeedScreen extends React.Component<Props> {
                 ref={value => this.ref = value || undefined}
             >
                 {{
-                    navigationHeader: <NavigationHeader
-                                    title='Home'
-                                    rightButton1={{
-                                        onPress: () => this.props.navigation.navigate('FeedListViewerContainer', {
-                                            showExplore: true,
-                                        }),
-                                        label: <Icon
-                                            name={'view-grid'}
-                                            size={20}
-                                            color={ComponentColors.NAVIGATION_BUTTON_COLOR}
-                                        />,
-                                    }}
-                                    onPressTitle={this.ref && this.ref.scrollToTop}
+                    navigationHeader:
+                        <NavigationHeader
+                            title='Home'
+                            leftButton={{
+                                onPress: () => this.props.navigation.navigate('FeedListViewerContainer', {
+                                    showExplore: true,
+                                }),
+                                label: <Icon
+                                    name={'menu'}
+                                    size={24}
+                                    color={ComponentColors.NAVIGATION_BUTTON_COLOR}
                                 />,
+                            }}
+                            rightButton1={{
+                                onPress: () => this.props.navigation.navigate('FeedInfo', {
+                                     feed: {
+                                         name: '',
+                                         url: '',
+                                         feedUrl: '',
+                                         favicon: '',
+                                     },
+                                }),
+                                label: <MaterialIcon
+                                    name='add-box'
+                                    size={24}
+                                    color={ComponentColors.NAVIGATION_BUTTON_COLOR}
+                                />,
+                            }}
+                            onPressTitle={this.ref && this.ref.scrollToTop}
+                        />,
                     listHeader: <FeedHeader
                                     navigation={this.props.navigation}
                                     onSaveDraft={this.props.onSaveDraft}

--- a/src/components/Backup.tsx
+++ b/src/components/Backup.tsx
@@ -12,7 +12,7 @@ import {
 import { NavigationHeader } from './NavigationHeader';
 import { SimpleTextInput } from './SimpleTextInput';
 import { Debug } from '../Debug';
-import { Colors, DefaultNavigationBarHeight } from '../styles';
+import { Colors, ComponentColors, DefaultNavigationBarHeight } from '../styles';
 import { Button } from './Button';
 import {
     backupToSwarm,
@@ -161,6 +161,7 @@ const styles = StyleSheet.create({
     mainContainer: {
         height: '100%',
         flexDirection: 'column',
+        backgroundColor: ComponentColors.HEADER_COLOR,
     },
     backupTextInput: {
         fontSize: 10,

--- a/src/components/BackupRestore.tsx
+++ b/src/components/BackupRestore.tsx
@@ -7,6 +7,8 @@ import {
 import { NavigationHeader } from './NavigationHeader';
 import { Button } from './Button';
 import { TypedNavigation, Routes } from '../helpers/navigation';
+import { ComponentColors } from '../styles';
+import { FragmentSafeAreaView } from '../ui/misc/FragmentSafeAreaView';
 
 export interface StateProps {
     navigation: TypedNavigation;
@@ -21,7 +23,7 @@ export interface State {
 }
 
 export const BackupRestore = (props: Props) => (
-    <SafeAreaView style={styles.mainContainer}>
+    <FragmentSafeAreaView style={styles.mainContainer}>
         <NavigationHeader
             title='Backup & Restore'
             navigation={props.navigation}
@@ -30,13 +32,14 @@ export const BackupRestore = (props: Props) => (
             <Button text='Backup' onPress={() => props.navigation.navigate('Backup', {})} />
             <Button text='Restore' onPress={() => props.navigation.navigate('Restore', {})} />
         </View>
-    </SafeAreaView>
+    </FragmentSafeAreaView>
 );
 
 const styles = StyleSheet.create({
     mainContainer: {
         height: '100%',
         flexDirection: 'column',
+        backgroundColor: ComponentColors.BACKGROUND_COLOR,
     },
     buttonContainer: {
         flex: 1,

--- a/src/components/BugReportView.tsx
+++ b/src/components/BugReportView.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { NavigationHeader } from './NavigationHeader';
-import { Colors } from '../styles';
+import { Colors, ComponentColors } from '../styles';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { View, StyleSheet, SafeAreaView, ActivityIndicator } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
@@ -87,7 +87,7 @@ export class BugReportView extends React.Component<Props, State> {
                         label: <Icon
                             name={'send'}
                             size={20}
-                            color={Colors.NAVIGATION_BUTTON_COLOR}
+                            color={ComponentColors.NAVIGATION_BUTTON_COLOR}
                         />,
                     }}
                 />
@@ -96,7 +96,7 @@ export class BugReportView extends React.Component<Props, State> {
                         <BugIcon
                             width={29}
                             height={29}
-                            fill={Colors.BRAND_PURPLE}
+                            fill={Colors.WHITE}
                         />
                     </View>
                     {this.props.errorView &&
@@ -160,13 +160,15 @@ export class BugReportView extends React.Component<Props, State> {
 
 const styles = StyleSheet.create({
     mainContainer: {
-        backgroundColor: Colors.WHITE,
+        backgroundColor: Colors.BRAND_PURPLE,
         flex: 1,
     },
     contentContainer: {
         paddingTop: 25,
         flexDirection: 'column',
         alignItems: 'center',
+        backgroundColor: Colors.WHITE,
+        flex: 1,
     },
     iconContainer: {
     },

--- a/src/components/BugReportView.tsx
+++ b/src/components/BugReportView.tsx
@@ -87,7 +87,7 @@ export class BugReportView extends React.Component<Props, State> {
                         label: <Icon
                             name={'send'}
                             size={20}
-                            color={Colors.BRAND_PURPLE}
+                            color={Colors.NAVIGATION_BUTTON_COLOR}
                         />,
                     }}
                 />

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { StyleSheet, ViewProperties } from 'react-native';
 import { TouchableView } from './TouchableView';
-import { Colors } from '../styles';
+import { ComponentColors } from '../styles';
 import { RegularText } from '../ui/misc/text';
 
 export interface StateProps extends ViewProperties {
@@ -22,7 +22,7 @@ export const Button = (props: Props) => {
     const isButtonEnabled = props.enabled != null
                                 ? props.enabled
                                 : true;
-    const buttonColor = isButtonEnabled ? Colors.BUTTON_COLOR : Colors.LIGHT_GRAY;
+    const buttonColor = isButtonEnabled ? ComponentColors.BUTTON_COLOR : ComponentColors.DISABLED_BUTTON_COLOR;
     return (
         <TouchableView
             onPress={isButtonEnabled ? props.onPress : undefined}
@@ -42,6 +42,6 @@ const styles = StyleSheet.create({
     },
     buttonText: {
         fontSize: 18,
-        color: Colors.BUTTON_COLOR,
+        color: ComponentColors.BUTTON_COLOR,
     },
 });

--- a/src/components/DebugScreen.tsx
+++ b/src/components/DebugScreen.tsx
@@ -10,7 +10,7 @@ import { AppState } from '../reducers/AppState';
 import { Debug } from '../Debug';
 import { NavigationHeader } from './NavigationHeader';
 import * as AreYouSureDialog from './AreYouSureDialog';
-import { Colors } from '../styles';
+import { ComponentColors, Colors } from '../styles';
 import { RowItem } from '../ui/misc/RowButton';
 import * as Swarm from '../swarm/Swarm';
 import { restartApp } from '../helpers/restart';
@@ -57,7 +57,7 @@ const MaterialCommunityIcon = (props: IconProps) => (
 );
 
 export const DebugScreen = (props: Props) => (
-    <SafeAreaView style={{ backgroundColor: '#EFEFF4', flex: 1 }}>
+    <SafeAreaView style={{ backgroundColor: ComponentColors.HEADER_COLOR, flex: 1 }}>
         <NavigationHeader
             navigation={props.navigation}
             title='Debug menu'

--- a/src/components/EditFilter.tsx
+++ b/src/components/EditFilter.tsx
@@ -10,12 +10,13 @@ import {
 import Icon from 'react-native-vector-icons/MaterialIcons';
 
 import { ContentFilter, filterValidUntilToText } from '../models/ContentFilter';
-import { Colors } from '../styles';
+import { ComponentColors } from '../styles';
 import { HOUR, DAY, MONTH31, WEEK } from '../DateUtils';
 import { SimpleTextInput } from './SimpleTextInput';
 import { Debug } from '../Debug';
 import { NavigationHeader } from './NavigationHeader';
 import { TypedNavigation } from '../helpers/navigation';
+import { FragmentSafeAreaView } from '../ui/misc/FragmentSafeAreaView';
 
 type SliderValue = 0 | 1 | 2 | 3 | 4 | 5;
 
@@ -79,17 +80,17 @@ export class EditFilter extends React.Component<DispatchProps & StateProps, Edit
             ? <Icon
                 name='delete'
                 size={20}
-                color={Colors.NAVIGATION_BUTTON_COLOR}
+                color={ComponentColors.NAVIGATION_BUTTON_COLOR}
             />
             : <Icon
                 name='add-box'
                 size={20}
-                color={Colors.NAVIGATION_BUTTON_COLOR}
+                color={ComponentColors.NAVIGATION_BUTTON_COLOR}
             />
             ;
         const rightButtonAction = isDelete ? this.onDeleteFilter : this.onAddFilter;
         return (
-            <SafeAreaView style={styles.container}>
+            <FragmentSafeAreaView style={styles.container}>
                 <NavigationHeader
                     title='Edit filter'
                     navigation={this.props.navigation}
@@ -118,7 +119,7 @@ export class EditFilter extends React.Component<DispatchProps & StateProps, Edit
                         onValueChange={(value) => this.setState({ filterSliderValue: value as SliderValue })}
                     />
                 </View>
-            </SafeAreaView>
+            </FragmentSafeAreaView>
         );
     }
 
@@ -157,7 +158,7 @@ export class EditFilter extends React.Component<DispatchProps & StateProps, Edit
 
 const styles = StyleSheet.create({
     container: {
-        backgroundColor: Colors.BACKGROUND_COLOR,
+        backgroundColor: ComponentColors.HEADER_COLOR,
         flex: 1,
         flexDirection: 'column',
     },
@@ -199,7 +200,7 @@ const styles = StyleSheet.create({
     },
     sliderText: {
         flex: 1,
-        color: Colors.GRAY,
+        color: ComponentColors.TEXT_COLOR,
         paddingTop: 20,
     },
     slider: {

--- a/src/components/EditFilter.tsx
+++ b/src/components/EditFilter.tsx
@@ -79,12 +79,12 @@ export class EditFilter extends React.Component<DispatchProps & StateProps, Edit
             ? <Icon
                 name='delete'
                 size={20}
-                color={Colors.DARK_GRAY}
+                color={Colors.NAVIGATION_BUTTON_COLOR}
             />
             : <Icon
                 name='add-box'
                 size={20}
-                color={Colors.DARK_GRAY}
+                color={Colors.NAVIGATION_BUTTON_COLOR}
             />
             ;
         const rightButtonAction = isDelete ? this.onDeleteFilter : this.onAddFilter;

--- a/src/components/FavoritesFeedView.tsx
+++ b/src/components/FavoritesFeedView.tsx
@@ -45,7 +45,7 @@ export const FavoritesFeedView = (props: Props) => {
                             label: <Icon
                                 name={'view-grid'}
                                 size={20}
-                                color={Colors.DARK_GRAY}
+                                color={Colors.NAVIGATION_BUTTON_COLOR}
                             />,
                         }}
                     />,

--- a/src/components/FavoritesFeedView.tsx
+++ b/src/components/FavoritesFeedView.tsx
@@ -36,15 +36,15 @@ export const FavoritesFeedView = (props: Props) => {
                 navigationHeader:
                     <NavigationHeader
                         title='Favorites'
-                        rightButton1={{
+                        leftButton={{
                             onPress: () => props.navigation.navigate(
                                 'FavoriteListViewerContainer', {
                                     feeds: props.feeds,
                                 }
                             ),
                             label: <Icon
-                                name={'view-grid'}
-                                size={20}
+                                name={'menu'}
+                                size={24}
                                 color={ComponentColors.NAVIGATION_BUTTON_COLOR}
                             />,
                         }}

--- a/src/components/FavoritesFeedView.tsx
+++ b/src/components/FavoritesFeedView.tsx
@@ -3,7 +3,7 @@ import { RefreshableFeed } from './RefreshableFeed';
 import { Feed } from '../models/Feed';
 import { Post } from '../models/Post';
 import { NavigationHeader } from './NavigationHeader';
-import { Colors } from '../styles';
+import { Colors, ComponentColors } from '../styles';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { ReactNativeModelHelper } from '../models/ReactNativeModelHelper';
 import { PlaceholderCard } from '../ui/misc/PlaceholderCard';
@@ -45,7 +45,7 @@ export const FavoritesFeedView = (props: Props) => {
                             label: <Icon
                                 name={'view-grid'}
                                 size={20}
-                                color={Colors.NAVIGATION_BUTTON_COLOR}
+                                color={ComponentColors.NAVIGATION_BUTTON_COLOR}
                             />,
                         }}
                     />,

--- a/src/components/FeedInfo.tsx
+++ b/src/components/FeedInfo.tsx
@@ -17,7 +17,7 @@ import * as urlUtils from '../helpers/urlUtils';
 import { Feed } from '../models/Feed';
 import { SimpleTextInput } from './SimpleTextInput';
 import { Debug } from '../Debug';
-import { Colors } from '../styles';
+import { ComponentColors, Colors } from '../styles';
 import * as Swarm from '../swarm/Swarm';
 import { downloadRecentPostFeed } from '../swarm-social/swarmStorage';
 import { NavigationHeader } from './NavigationHeader';
@@ -110,7 +110,7 @@ export class FeedInfo extends React.Component<Props, FeedInfoState> {
         const isExistingFeed = this.props.feed.feedUrl.length > 0;
         const isFollowed = this.props.feed.followed;
 
-        const icon = (name: string) => <Icon name={name} size={20} color={Colors.NAVIGATION_BUTTON_COLOR} />;
+        const icon = (name: string) => <Icon name={name} size={20} color={ComponentColors.NAVIGATION_BUTTON_COLOR} />;
         const button = (iconName: string, onPress: () => void) => ({
             label: icon(iconName),
             onPress,
@@ -191,7 +191,7 @@ export class FeedInfo extends React.Component<Props, FeedInfoState> {
                         value={qrCodeValue}
                         size={QRCodeWidth}
                         color={Colors.DARK_GRAY}
-                        backgroundColor={Colors.BACKGROUND_COLOR}
+                        backgroundColor={ComponentColors.BACKGROUND_COLOR}
                     />
                 </View>
             </View>
@@ -289,12 +289,12 @@ export class FeedInfo extends React.Component<Props, FeedInfoState> {
 
 const styles = StyleSheet.create({
     mainContainer: {
-        backgroundColor: Colors.WHITE,
+        backgroundColor: ComponentColors.HEADER_COLOR,
         flex: 1,
         flexDirection: 'column',
     },
     container: {
-        backgroundColor: Colors.BACKGROUND_COLOR,
+        backgroundColor: ComponentColors.BACKGROUND_COLOR,
         flex: 1,
         flexDirection: 'column',
     },
@@ -327,7 +327,7 @@ const styles = StyleSheet.create({
         justifyContent: 'center',
         flexDirection: 'column',
         height: 100,
-        backgroundColor: Colors.BACKGROUND_COLOR,
+        backgroundColor: ComponentColors.BACKGROUND_COLOR,
         paddingTop: 50,
     },
     qrCodeContainer: {

--- a/src/components/FeedInfo.tsx
+++ b/src/components/FeedInfo.tsx
@@ -24,6 +24,7 @@ import { NavigationHeader } from './NavigationHeader';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { unfollowFeed } from './FeedView';
 import { TypedNavigation, Routes } from '../helpers/navigation';
+import { FragmentSafeAreaView } from '../ui/misc/FragmentSafeAreaView';
 
 const QRCodeWidth = Dimensions.get('window').width * 0.6;
 const QRCodeHeight = QRCodeWidth;
@@ -126,7 +127,7 @@ export class FeedInfo extends React.Component<Props, FeedInfoState> {
         ;
 
         return (
-            <SafeAreaView style={styles.mainContainer}>
+            <FragmentSafeAreaView>
                 <NavigationHeader
                     title={isExistingFeed ? 'Feed Info' : 'Add Feed'}
                     rightButton1={rightButton1}
@@ -157,7 +158,7 @@ export class FeedInfo extends React.Component<Props, FeedInfoState> {
                         : <this.NewItemView showQRCamera={this.state.showQRCamera} />
                     }
                 </View>
-            </SafeAreaView>
+            </FragmentSafeAreaView>
         );
     }
 

--- a/src/components/FeedInfo.tsx
+++ b/src/components/FeedInfo.tsx
@@ -110,7 +110,7 @@ export class FeedInfo extends React.Component<Props, FeedInfoState> {
         const isExistingFeed = this.props.feed.feedUrl.length > 0;
         const isFollowed = this.props.feed.followed;
 
-        const icon = (name: string) => <Icon name={name} size={20} color={Colors.DARK_GRAY} />;
+        const icon = (name: string) => <Icon name={name} size={20} color={Colors.NAVIGATION_BUTTON_COLOR} />;
         const button = (iconName: string, onPress: () => void) => ({
             label: icon(iconName),
             onPress,

--- a/src/components/FeedListEditor.tsx
+++ b/src/components/FeedListEditor.tsx
@@ -83,7 +83,7 @@ export class FeedListEditor extends React.PureComponent<DispatchProps & StatePro
                         navigation={this.props.navigation}
                         rightButton1={{
                             onPress: this.onAddFeed,
-                            label: <MaterialIcon name='add-box' size={24} color={Colors.BUTTON_COLOR} />,
+                            label: <MaterialIcon name='add-box' size={24} color={Colors.NAVIGATION_BUTTON_COLOR} />,
                         }}
                         title={this.props.title}
                     />

--- a/src/components/FeedListEditor.tsx
+++ b/src/components/FeedListEditor.tsx
@@ -5,7 +5,7 @@ import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 import { Feed } from '../models/Feed';
 import { ImageData } from '../models/ImageData';
-import { Colors } from '../styles';
+import { Colors, ComponentColors } from '../styles';
 import { NavigationHeader } from './NavigationHeader';
 import { SuperGridSectionList } from 'react-native-super-grid';
 import { GridCard, getGridCardSize } from '../ui/misc/GridCard';
@@ -38,7 +38,7 @@ export class FeedGrid extends React.PureComponent<DispatchProps & StateProps & {
         const itemDimension = getGridCardSize();
         const modelHelper = new ReactNativeModelHelper(this.props.gatewayAddress);
         return (
-            <View style={{ backgroundColor: Colors.BACKGROUND_COLOR, flex: 1 }}>
+            <View style={{ backgroundColor: ComponentColors.BACKGROUND_COLOR, flex: 1 }}>
                 {this.props.children}
                 <SuperGridSectionList
                     style={{ flex: 1 }}
@@ -77,13 +77,13 @@ export class FeedGrid extends React.PureComponent<DispatchProps & StateProps & {
 export class FeedListEditor extends React.PureComponent<DispatchProps & StateProps> {
     public render() {
         return (
-            <SafeAreaView style={{ backgroundColor: Colors.WHITE, flex: 1 }}>
+            <SafeAreaView style={{ backgroundColor: Colors.BRAND_PURPLE, flex: 1 }}>
                 <FeedGrid {...this.props}>
                     <NavigationHeader
                         navigation={this.props.navigation}
                         rightButton1={{
                             onPress: this.onAddFeed,
-                            label: <MaterialIcon name='add-box' size={24} color={Colors.NAVIGATION_BUTTON_COLOR} />,
+                            label: <MaterialIcon name='add-box' size={24} color={ComponentColors.NAVIGATION_BUTTON_COLOR} />,
                         }}
                         title={this.props.title}
                     />
@@ -126,7 +126,7 @@ const styles = StyleSheet.create({
         paddingTop: 20,
         paddingBottom: 7,
         color: Colors.DARK_GRAY,
-        backgroundColor: Colors.BACKGROUND_COLOR,
+        backgroundColor: ComponentColors.BACKGROUND_COLOR,
         fontSize: 14,
     },
 });

--- a/src/components/FeedListEditor.tsx
+++ b/src/components/FeedListEditor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, StyleSheet, SafeAreaView, TouchableWithoutFeedback } from 'react-native';
+import { View, StyleSheet, TouchableWithoutFeedback, SafeAreaView } from 'react-native';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
@@ -14,6 +14,7 @@ import { MediumText } from '../ui/misc/text';
 import { TabBarPlaceholder } from '../ui/misc/TabBarPlaceholder';
 import { defaultImages } from '../defaultImages';
 import { TypedNavigation } from '../helpers/navigation';
+import { FragmentSafeAreaView } from '../ui/misc/FragmentSafeAreaView';
 
 export interface DispatchProps {
     onPressFeed: (feed: Feed) => void;
@@ -38,7 +39,7 @@ export class FeedGrid extends React.PureComponent<DispatchProps & StateProps & {
         const itemDimension = getGridCardSize();
         const modelHelper = new ReactNativeModelHelper(this.props.gatewayAddress);
         return (
-            <View style={{ backgroundColor: ComponentColors.BACKGROUND_COLOR, flex: 1 }}>
+            <SafeAreaView style={{ backgroundColor: ComponentColors.BACKGROUND_COLOR, flex: 1 }}>
                 {this.props.children}
                 <SuperGridSectionList
                     style={{ flex: 1 }}
@@ -69,7 +70,7 @@ export class FeedGrid extends React.PureComponent<DispatchProps & StateProps & {
                     // @ts-ignore - SuperGridSectionList is passing props to internal SectionList, typings is missing
                     ListFooterComponent={<TabBarPlaceholder color={Colors.BACKGROUND_COLOR}/>}
                 />
-            </View>
+            </SafeAreaView>
         );
     }
 }
@@ -77,7 +78,7 @@ export class FeedGrid extends React.PureComponent<DispatchProps & StateProps & {
 export class FeedListEditor extends React.PureComponent<DispatchProps & StateProps> {
     public render() {
         return (
-            <SafeAreaView style={{ backgroundColor: Colors.BRAND_PURPLE, flex: 1 }}>
+            <FragmentSafeAreaView>
                 <FeedGrid {...this.props}>
                     <NavigationHeader
                         navigation={this.props.navigation}
@@ -105,7 +106,7 @@ export class FeedListEditor extends React.PureComponent<DispatchProps & StatePro
                         </View>
                     </TouchableWithoutFeedback>}
                 </FeedGrid>
-            </SafeAreaView>
+            </FragmentSafeAreaView>
         );
     }
 

--- a/src/components/FeedView.tsx
+++ b/src/components/FeedView.tsx
@@ -3,7 +3,7 @@ import { RefreshableFeed } from './RefreshableFeed';
 import { Feed } from '../models/Feed';
 import { Post } from '../models/Post';
 import { NavigationHeader, HeaderDefaultLeftButtonIcon } from './NavigationHeader';
-import { Colors } from '../styles';
+import { ComponentColors } from '../styles';
 
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import * as AreYouSureDialog from './AreYouSureDialog';
@@ -61,20 +61,20 @@ export const FeedView = (props: Props) => {
 
     const rightButton1 = props.isOwnFeed
         ? props.feedName.length > 0
-            ? button('dots-vertical', Colors.NAVIGATION_BUTTON_COLOR, navigateToFeedSettings)
+            ? button('dots-vertical', ComponentColors.NAVIGATION_BUTTON_COLOR, navigateToFeedSettings)
             : undefined
         : isOnboardingFeed
             ? undefined
             : isFollowedFeed
                 ? isFavorite(props.feeds, props.feedUrl)
-                    ? button('star', Colors.NAVIGATION_BUTTON_COLOR, toggleFavorite)
-                    : button('star-outline', Colors.NAVIGATION_BUTTON_COLOR, toggleFavorite)
-                : button('link-variant', Colors.NAVIGATION_BUTTON_COLOR, onLinkPressed)
+                    ? button('star', ComponentColors.NAVIGATION_BUTTON_COLOR, toggleFavorite)
+                    : button('star-outline', ComponentColors.NAVIGATION_BUTTON_COLOR, toggleFavorite)
+                : button('link-variant', ComponentColors.NAVIGATION_BUTTON_COLOR, onLinkPressed)
     ;
 
     const rightButton2 = isLocalFeed || isOnboardingFeed
         ? undefined
-        : button('dots-vertical', Colors.NAVIGATION_BUTTON_COLOR, navigateToFeedInfo)
+        : button('dots-vertical', ComponentColors.NAVIGATION_BUTTON_COLOR, navigateToFeedInfo)
     ;
     return (
         <RefreshableFeed modelHelper={modelHelper} {...props}>

--- a/src/components/FeedView.tsx
+++ b/src/components/FeedView.tsx
@@ -61,20 +61,20 @@ export const FeedView = (props: Props) => {
 
     const rightButton1 = props.isOwnFeed
         ? props.feedName.length > 0
-            ? button('dots-vertical', Colors.DARK_GRAY, navigateToFeedSettings)
+            ? button('dots-vertical', Colors.NAVIGATION_BUTTON_COLOR, navigateToFeedSettings)
             : undefined
         : isOnboardingFeed
             ? undefined
             : isFollowedFeed
                 ? isFavorite(props.feeds, props.feedUrl)
-                    ? button('star', Colors.BRAND_PURPLE, toggleFavorite)
-                    : button('star', Colors.DARK_GRAY, toggleFavorite)
-                : button('link-variant', Colors.DARK_GRAY, onLinkPressed)
+                    ? button('star', Colors.NAVIGATION_BUTTON_COLOR, toggleFavorite)
+                    : button('star-outline', Colors.NAVIGATION_BUTTON_COLOR, toggleFavorite)
+                : button('link-variant', Colors.NAVIGATION_BUTTON_COLOR, onLinkPressed)
     ;
 
     const rightButton2 = isLocalFeed || isOnboardingFeed
         ? undefined
-        : button('dots-vertical', Colors.DARK_GRAY, navigateToFeedInfo)
+        : button('dots-vertical', Colors.NAVIGATION_BUTTON_COLOR, navigateToFeedInfo)
     ;
     return (
         <RefreshableFeed modelHelper={modelHelper} {...props}>

--- a/src/components/FilterListEditor.tsx
+++ b/src/components/FilterListEditor.tsx
@@ -4,7 +4,7 @@ import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import { ContentFilter } from '../models/ContentFilter';
 import { DateUtils } from '../DateUtils';
 import { NavigationHeader } from './NavigationHeader';
-import { Colors } from '../styles';
+import { ComponentColors } from '../styles';
 import { RowItem } from '../ui/misc/RowButton';
 import { TypedNavigation, Routes } from '../helpers/navigation';
 
@@ -26,10 +26,10 @@ export class FilterListEditor extends React.Component<StateProps & DispatchProps
                     navigation={this.props.navigation}
                     rightButton1={{
                         onPress: this.onAddFilter,
-                        label: <MaterialIcon name='add-box' size={24} color={Colors.NAVIGATION_BUTTON_COLOR} />,
+                        label: <MaterialIcon name='add-box' size={24} color={ComponentColors.NAVIGATION_BUTTON_COLOR} />,
                     }}
                 />
-                <ScrollView style={{ backgroundColor: Colors.BACKGROUND_COLOR }}>
+                <ScrollView style={{ backgroundColor: ComponentColors.BACKGROUND_COLOR }}>
                     {this.props.filters.map(filter => (
                         <RowItem
                             title={filter.text}
@@ -65,6 +65,6 @@ export class FilterListEditor extends React.Component<StateProps & DispatchProps
 const styles = StyleSheet.create({
     container: {
         flex: 1,
-        backgroundColor: Colors.WHITE,
+        backgroundColor: ComponentColors.HEADER_COLOR,
     },
 });

--- a/src/components/FilterListEditor.tsx
+++ b/src/components/FilterListEditor.tsx
@@ -26,7 +26,7 @@ export class FilterListEditor extends React.Component<StateProps & DispatchProps
                     navigation={this.props.navigation}
                     rightButton1={{
                         onPress: this.onAddFilter,
-                        label: <MaterialIcon name='add-box' size={24} color={Colors.BUTTON_COLOR} />,
+                        label: <MaterialIcon name='add-box' size={24} color={Colors.NAVIGATION_BUTTON_COLOR} />,
                     }}
                 />
                 <ScrollView style={{ backgroundColor: Colors.BACKGROUND_COLOR }}>

--- a/src/components/IdentitySettings.tsx
+++ b/src/components/IdentitySettings.tsx
@@ -93,7 +93,7 @@ export const IdentitySettings = (props: DispatchProps & StateProps) => {
                                 label: <MaterialCommunityIcon
                                     name={'share'}
                                     size={20}
-                                    color={Colors.DARK_GRAY}
+                                    color={Colors.NAVIGATION_BUTTON_COLOR}
                                 />,
                                 onPress: async () => showShareDialog(props.ownFeed),
                             }

--- a/src/components/IdentitySettings.tsx
+++ b/src/components/IdentitySettings.tsx
@@ -4,7 +4,6 @@ import {
     KeyboardAvoidingView,
     StyleSheet,
     View,
-    Text,
     Image,
     TouchableOpacity,
     Dimensions,
@@ -22,7 +21,7 @@ import { Author } from '../models/Author';
 import { ImageData } from '../models/ImageData';
 import { Feed } from '../models/Feed';
 import { AsyncImagePicker } from '../AsyncImagePicker';
-import { Colors } from '../styles';
+import { ComponentColors, Colors } from '../styles';
 import { NavigationHeader } from './NavigationHeader';
 import { Debug } from '../Debug';
 import { ReactNativeModelHelper } from '../models/ReactNativeModelHelper';
@@ -93,7 +92,7 @@ export const IdentitySettings = (props: DispatchProps & StateProps) => {
                                 label: <MaterialCommunityIcon
                                     name={'share'}
                                     size={20}
-                                    color={Colors.NAVIGATION_BUTTON_COLOR}
+                                    color={ComponentColors.NAVIGATION_BUTTON_COLOR}
                                 />,
                                 onPress: async () => showShareDialog(props.ownFeed),
                             }
@@ -146,7 +145,7 @@ export const IdentitySettings = (props: DispatchProps & StateProps) => {
                                 value={qrCodeValue}
                                 size={QRCodeWidth}
                                 color={Colors.DARK_GRAY}
-                                backgroundColor={Colors.BACKGROUND_COLOR}
+                                backgroundColor={ComponentColors.BACKGROUND_COLOR}
                             />
                         </View>
                     }
@@ -166,11 +165,11 @@ const openImagePicker = async (onUpdatePicture: (imageData: ImageData) => void) 
 
 const styles = StyleSheet.create({
     safeAreaContainer: {
-        backgroundColor: Colors.WHITE,
+        backgroundColor: ComponentColors.HEADER_COLOR,
         flex: 1,
     },
     mainContainer: {
-        backgroundColor: Colors.BACKGROUND_COLOR,
+        backgroundColor: ComponentColors.BACKGROUND_COLOR,
         flex: 1,
     },
     row: {

--- a/src/components/LogViewer.tsx
+++ b/src/components/LogViewer.tsx
@@ -11,9 +11,10 @@ import Ionicon from 'react-native-vector-icons/Ionicons';
 
 import { NavigationHeader } from './NavigationHeader';
 import { clearLog, filteredLog, setLogFilter } from '../log';
-import { Colors, DefaultTabBarHeight } from '../styles';
+import { Colors, ComponentColors, DefaultTabBarHeight } from '../styles';
 import { SimpleTextInput } from './SimpleTextInput';
 import { TypedNavigation } from '../helpers/navigation';
+import { FragmentSafeAreaView } from '../ui/misc/FragmentSafeAreaView';
 
 export interface StateProps {
     currentTimestamp: number;
@@ -39,7 +40,7 @@ export class LogViewer extends React.PureComponent<Props> {
     }
 
     public render = () => (
-        <SafeAreaView style={styles.mainContainer}>
+        <FragmentSafeAreaView style={styles.mainContainer}>
             <NavigationHeader
                 navigation={this.props.navigation}
                 rightButton1={{
@@ -78,7 +79,7 @@ export class LogViewer extends React.PureComponent<Props> {
                 }
                 keyExtractor={(item) => item[0]}
             />
-        </SafeAreaView>
+        </FragmentSafeAreaView>
     )
 }
 
@@ -86,7 +87,7 @@ const fontFamily = Platform.OS === 'ios' ? 'Courier' : 'monospace';
 const styles = StyleSheet.create({
     mainContainer: {
         height: Dimensions.get('window').height - DefaultTabBarHeight + 1,
-        backgroundColor: Colors.BACKGROUND_COLOR,
+        backgroundColor: ComponentColors.HEADER_COLOR,
     },
     logLineContainer: {
     },
@@ -94,7 +95,7 @@ const styles = StyleSheet.create({
         height: 40,
         paddingHorizontal: 16,
         paddingVertical: 6,
-        backgroundColor: Colors.BACKGROUND_COLOR,
+        backgroundColor: ComponentColors.BACKGROUND_COLOR,
     },
     logFilterTextInputContainer: {
         borderRadius: 16,

--- a/src/components/NavigationHeader.tsx
+++ b/src/components/NavigationHeader.tsx
@@ -24,7 +24,7 @@ interface HeaderProps {
 
 export type Props = HeaderProps;
 
-const BUTTON_COLOR = Colors.DARK_GRAY;
+const BUTTON_COLOR = Colors.WHITE;
 
 export const HeaderDefaultLeftButtonIcon = <Icon name={'arrow-left'} color={BUTTON_COLOR} size={24} />;
 
@@ -97,10 +97,10 @@ const styles = StyleSheet.create({
         paddingTop: 2,
         borderBottomWidth: 1,
         borderBottomColor: Colors.LIGHT_GRAY,
-        backgroundColor: Colors.WHITE,
+        backgroundColor: Colors.BRAND_PURPLE,
     },
     headerLeftButtonText: {
-        color: BUTTON_COLOR,
+        color: Colors.WHITE,
         fontSize: 18,
     },
     leftContainer: {
@@ -119,12 +119,12 @@ const styles = StyleSheet.create({
     },
     titleText: {
         fontSize: 15,
-        color: Colors.DARK_GRAY,
+        color: Colors.WHITE,
         textAlign: 'center',
     },
     headerRightButtonText: {
         fontSize: 18,
-        color: BUTTON_COLOR,
+        color: Colors.WHITE,
     },
     rightButtonContainer: {
         marginLeft: 30,

--- a/src/components/NavigationHeader.tsx
+++ b/src/components/NavigationHeader.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { View, StyleSheet } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
-import { Colors, DefaultNavigationBarHeight } from '../styles';
+import { Colors, ComponentColors, DefaultNavigationBarHeight } from '../styles';
 import { TouchableView, TouchableViewDefaultHitSlop } from './TouchableView';
 import { MediumText, RegularText } from '../ui/misc/text';
 import { TypedNavigation } from '../helpers/navigation';
@@ -95,9 +95,9 @@ const styles = StyleSheet.create({
         paddingLeft: 10,
         paddingRight: 10,
         paddingTop: 2,
-        borderBottomWidth: 1,
+        borderBottomWidth: 0,
         borderBottomColor: Colors.LIGHT_GRAY,
-        backgroundColor: Colors.BRAND_PURPLE,
+        backgroundColor: ComponentColors.HEADER_COLOR,
     },
     headerLeftButtonText: {
         color: Colors.WHITE,

--- a/src/components/PostEditor.tsx
+++ b/src/components/PostEditor.tsx
@@ -63,7 +63,7 @@ export class PostEditor extends React.Component<Props, State> {
     public render() {
         const isPostEmpty = this.isPostEmpty();
         const isSendEnabled = !isPostEmpty && !this.state.isSending;
-        const sendIconColor = isSendEnabled ? Colors.BRAND_PURPLE : Colors.GRAY;
+        const sendIconColor = isSendEnabled ? Colors.NAVIGATION_BUTTON_COLOR : Colors.BRAND_PURPLE;
         const sendIcon = <Icon name='send' size={20} color={sendIconColor} />;
         const sendButtonOnPress = isSendEnabled ? this.onPressSubmit : () => {};
         return (
@@ -79,7 +79,7 @@ export class PostEditor extends React.Component<Props, State> {
                             label: <Icon
                                 name={'close'}
                                 size={20}
-                                color={Colors.DARK_GRAY}
+                                color={Colors.NAVIGATION_BUTTON_COLOR}
                             />,
                         }}
                         rightButton1={{

--- a/src/components/PostEditor.tsx
+++ b/src/components/PostEditor.tsx
@@ -18,13 +18,14 @@ import { SimpleTextInput } from './SimpleTextInput';
 import { NavigationHeader } from './NavigationHeader';
 import { Debug } from '../Debug';
 import { markdownEscape, markdownUnescape } from '../markdown';
-import { Colors } from '../styles';
+import { ComponentColors, Colors } from '../styles';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { Avatar } from '../ui/misc/Avatar';
 import { ReactNativeModelHelper } from '../models/ReactNativeModelHelper';
 import { ModelHelper } from '../models/ModelHelper';
 import { TouchableViewDefaultHitSlop } from './TouchableView';
 import { TypedNavigation } from '../helpers/navigation';
+import { FragmentSafeAreaView } from '../ui/misc/FragmentSafeAreaView';
 
 export interface StateProps {
     navigation: TypedNavigation;
@@ -63,11 +64,11 @@ export class PostEditor extends React.Component<Props, State> {
     public render() {
         const isPostEmpty = this.isPostEmpty();
         const isSendEnabled = !isPostEmpty && !this.state.isSending;
-        const sendIconColor = isSendEnabled ? Colors.NAVIGATION_BUTTON_COLOR : Colors.BRAND_PURPLE;
+        const sendIconColor = isSendEnabled ? ComponentColors.NAVIGATION_BUTTON_COLOR : ComponentColors.HEADER_COLOR;
         const sendIcon = <Icon name='send' size={20} color={sendIconColor} />;
         const sendButtonOnPress = isSendEnabled ? this.onPressSubmit : () => {};
         return (
-            <SafeAreaView style={styles.container}>
+            <FragmentSafeAreaView style={styles.mainContainer}>
                 <KeyboardAvoidingView
                     enabled={Platform.OS === 'ios'}
                     behavior='padding'
@@ -79,7 +80,7 @@ export class PostEditor extends React.Component<Props, State> {
                             label: <Icon
                                 name={'close'}
                                 size={20}
-                                color={Colors.NAVIGATION_BUTTON_COLOR}
+                                color={ComponentColors.NAVIGATION_BUTTON_COLOR}
                             />,
                         }}
                         rightButton1={{
@@ -116,7 +117,7 @@ export class PostEditor extends React.Component<Props, State> {
                     />
                     <PhotoWidget onPressCamera={this.openCamera} onPressInsert={this.openImagePicker}/>
                 </KeyboardAvoidingView>
-            </SafeAreaView>
+            </FragmentSafeAreaView>
         );
     }
 
@@ -259,7 +260,7 @@ const PhotoWidget = React.memo((props: { onPressCamera: () => void, onPressInser
                 <Icon
                     name={'camera'}
                     size={24}
-                    color={Colors.DARK_GRAY}
+                    color={ComponentColors.BUTTON_COLOR}
                 />
             </TouchableOpacity>
             <TouchableOpacity
@@ -269,7 +270,7 @@ const PhotoWidget = React.memo((props: { onPressCamera: () => void, onPressInser
                 <Icon
                     name={'image-multiple'}
                     size={24}
-                    color={Colors.DARK_GRAY}
+                    color={ComponentColors.BUTTON_COLOR}
                 />
             </TouchableOpacity>
         </View>
@@ -277,10 +278,12 @@ const PhotoWidget = React.memo((props: { onPressCamera: () => void, onPressInser
 });
 
 const styles = StyleSheet.create({
+    mainContainer: {
+    },
     container: {
+        backgroundColor: Colors.WHITE,
         flex: 1,
         flexDirection: 'column',
-        backgroundColor: 'white',
     },
     textInput: {
         flex: 1,

--- a/src/components/RefreshableFeed.tsx
+++ b/src/components/RefreshableFeed.tsx
@@ -67,10 +67,10 @@ export class RefreshableFeed extends React.PureComponent<Props, RefreshableFeedS
         return (
             <SafeAreaView style={styles.container}>
                 <StatusBarView
-                    backgroundColor={Colors.WHITE}
+                    backgroundColor={Colors.BRAND_PURPLE}
                     hidden={false}
                     translucent={false}
-                    barStyle='dark-content'
+                    barStyle='light-content'
                     networkActivityIndicatorVisible={true}
                 />
                 {this.props.children.navigationHeader}

--- a/src/components/RefreshableFeed.tsx
+++ b/src/components/RefreshableFeed.tsx
@@ -5,10 +5,9 @@ import {
     RefreshControl,
     StyleSheet,
     LayoutAnimation,
-    SafeAreaView,
 } from 'react-native';
 import { Post } from '../models/Post';
-import { Colors } from '../styles';
+import { ComponentColors } from '../styles';
 import { StatusBarView } from './StatusBarView';
 import { Feed } from '../models/Feed';
 import { CardContainer } from '../containers/CardContainer';
@@ -16,6 +15,7 @@ import { Props as NavHeaderProps } from './NavigationHeader';
 import { Props as FeedHeaderProps } from './FeedHeader';
 import { ModelHelper } from '../models/ModelHelper';
 import { TypedNavigation } from '../helpers/navigation';
+import { FragmentSafeAreaView } from '../ui/misc/FragmentSafeAreaView';
 
 export interface DispatchProps {
     onRefreshPosts: (feeds: Feed[]) => void;
@@ -65,9 +65,9 @@ export class RefreshableFeed extends React.PureComponent<Props, RefreshableFeedS
 
     public render() {
         return (
-            <SafeAreaView style={styles.container}>
+            <FragmentSafeAreaView style={styles.container}>
                 <StatusBarView
-                    backgroundColor={Colors.BRAND_PURPLE}
+                    backgroundColor={ComponentColors.HEADER_COLOR}
                     hidden={false}
                     translucent={false}
                     barStyle='light-content'
@@ -98,11 +98,11 @@ export class RefreshableFeed extends React.PureComponent<Props, RefreshableFeedS
                         />
                     }
                     style={{
-                        backgroundColor: Colors.BACKGROUND_COLOR,
+                        backgroundColor: ComponentColors.BACKGROUND_COLOR,
                     }}
                     ref={value => this.flatList = value || undefined}
                 />
-            </SafeAreaView>
+            </FragmentSafeAreaView>
         );
     }
 
@@ -142,6 +142,6 @@ const styles = StyleSheet.create({
     container: {
         flexDirection: 'column',
         flex: 1,
-        backgroundColor: Colors.WHITE,
+        backgroundColor: ComponentColors.BACKGROUND_COLOR,
     },
 });

--- a/src/components/RefreshableFeed.tsx
+++ b/src/components/RefreshableFeed.tsx
@@ -66,13 +66,6 @@ export class RefreshableFeed extends React.PureComponent<Props, RefreshableFeedS
     public render() {
         return (
             <FragmentSafeAreaView style={styles.container}>
-                <StatusBarView
-                    backgroundColor={ComponentColors.HEADER_COLOR}
-                    hidden={false}
-                    translucent={false}
-                    barStyle='light-content'
-                    networkActivityIndicatorVisible={true}
-                />
                 {this.props.children.navigationHeader}
                 {this.props.feeds.length === 0 && this.props.children.placeholder}
                 <FlatList

--- a/src/components/Restore.tsx
+++ b/src/components/Restore.tsx
@@ -3,7 +3,7 @@ import { View, StyleSheet, Clipboard, Alert, SafeAreaView } from 'react-native';
 import { NavigationHeader } from './NavigationHeader';
 import { SimpleTextInput } from './SimpleTextInput';
 import { Debug } from '../Debug';
-import { Colors, DefaultNavigationBarHeight } from '../styles';
+import { Colors, ComponentColors, DefaultNavigationBarHeight } from '../styles';
 import { Button } from './Button';
 import {
     isValidBackupLinkData,
@@ -118,6 +118,7 @@ const styles = StyleSheet.create({
     mainContainer: {
         height: '100%',
         flexDirection: 'column',
+        backgroundColor: ComponentColors.HEADER_COLOR,
     },
     backupTextInput: {
         fontSize: 10,

--- a/src/components/SettingsEditor.tsx
+++ b/src/components/SettingsEditor.tsx
@@ -4,7 +4,7 @@ import Ionicons from 'react-native-vector-icons/Ionicons';
 
 import { Settings } from '../models/Settings';
 import { Version } from '../Version';
-import { Colors } from '../styles';
+import { Colors, ComponentColors } from '../styles';
 import { NavigationHeader } from './NavigationHeader';
 import { RowItem } from '../ui/misc/RowButton';
 import { SuperGridSectionList } from 'react-native-super-grid';
@@ -38,13 +38,13 @@ export const SettingsEditor = (props: Props) => {
     const modelHelper = new ReactNativeModelHelper(props.settings.swarmGatewayAddress);
     const itemDimension = getGridCardSize();
     return (
-        <SafeAreaView style={{ backgroundColor: Colors.WHITE, flex: 1 }}>
+        <SafeAreaView style={{ backgroundColor: ComponentColors.HEADER_COLOR, flex: 1 }}>
             <NavigationHeader
                 title='Settings'
             />
-            <ScrollView style={{ backgroundColor: Colors.BACKGROUND_COLOR }}>
+            <ScrollView style={{ backgroundColor: ComponentColors.BACKGROUND_COLOR }}>
                 <SuperGridSectionList
-                    style={{ flex: 1, backgroundColor: Colors.BACKGROUND_COLOR }}
+                    style={{ flex: 1, backgroundColor: ComponentColors.BACKGROUND_COLOR }}
                     spacing={GRID_SPACING}
                     fixed={true}
                     itemDimension={itemDimension}
@@ -105,7 +105,7 @@ export const SettingsEditor = (props: Props) => {
                 { props.settings.showDebugMenu &&
                 <RowItem
                     icon={
-                        <Ionicons name='md-bug' size={24} color={Colors.GRAY}/>
+                        <Ionicons name='md-bug' size={24} color={ComponentColors.BUTTON_COLOR}/>
                     }
                     title='Debug menu'
                     buttonStyle='navigate'

--- a/src/components/SwarmSettings.tsx
+++ b/src/components/SwarmSettings.tsx
@@ -10,7 +10,7 @@ import {
 
 import { NavigationHeader } from './NavigationHeader';
 import { SimpleTextInput } from './SimpleTextInput';
-import { Colors } from '../styles';
+import { Colors, ComponentColors } from '../styles';
 import { TypedNavigation } from '../helpers/navigation';
 
 export interface StateProps {
@@ -29,7 +29,7 @@ export interface State {
 
 export const SwarmSettings = (props: Props) => (
     <SafeAreaView style={styles.mainContainer}>
-        <KeyboardAvoidingView style={styles.mainContainer}>
+        <KeyboardAvoidingView style={styles.container}>
             <NavigationHeader
                 navigation={props.navigation}
                 title={'Swarm settings'}
@@ -54,6 +54,11 @@ export const SwarmSettings = (props: Props) => (
 const styles = StyleSheet.create({
     mainContainer: {
         height: '100%',
+        backgroundColor: ComponentColors.HEADER_COLOR,
+    },
+    container: {
+        height: '100%',
+        backgroundColor: ComponentColors.BACKGROUND_COLOR,
     },
     row: {
         width: '100%',

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -17,10 +17,15 @@ export const Colors = {
     DARK_GRAY: '#4A4A4A',
     BRAND_PURPLE: '#6200EA',
     BRAND_PURPLE_LIGHT: '#BA76FA',
+};
+export const ComponentColors = {
     STRONG_TEXT: '#303030',
+    TEXT_COLOR: Colors.GRAY,
     BACKGROUND_COLOR: '#DDDDDD',
-    BUTTON_COLOR: '#4A4A4A',
-    NAVIGATION_BUTTON_COLOR: '#FFFFFF',
+    DISABLED_BUTTON_COLOR: Colors.LIGHT_GRAY,
+    BUTTON_COLOR: Colors.DARK_GRAY,
+    NAVIGATION_BUTTON_COLOR: Colors.WHITE,
+    HEADER_COLOR: Colors.BRAND_PURPLE,
 };
 
 export const defaultBoldFont = 'Roboto-Bold';

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -15,11 +15,12 @@ export const Colors = {
     VERY_LIGHT_GRAY: '#F8F8F8',
     GRAY: '#808080',
     DARK_GRAY: '#4A4A4A',
-    BRAND_PURPLE: '#873FFF',
+    BRAND_PURPLE: '#6200EA',
     BRAND_PURPLE_LIGHT: '#BA76FA',
     STRONG_TEXT: '#303030',
     BACKGROUND_COLOR: '#DDDDDD',
     BUTTON_COLOR: '#4A4A4A',
+    NAVIGATION_BUTTON_COLOR: '#FFFFFF',
 };
 
 export const defaultBoldFont = 'Roboto-Bold';

--- a/src/ui/misc/FragmentSafeAreaView.tsx
+++ b/src/ui/misc/FragmentSafeAreaView.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { SafeAreaView, ViewProps } from 'react-native';
+import { ComponentColors } from '../../styles';
+import { StatusBarView } from '../../components/StatusBarView';
+
+export const FragmentSafeAreaView = (props: ViewProps & { children: any }) => (
+    <React.Fragment>
+        <StatusBarView
+            backgroundColor={ComponentColors.HEADER_COLOR}
+            hidden={false}
+            translucent={false}
+            barStyle='light-content'
+            networkActivityIndicatorVisible={true}
+        />
+
+        <SafeAreaView style={{ flex: 0, backgroundColor: ComponentColors.HEADER_COLOR }} />
+        {props.children}
+    </React.Fragment>
+);

--- a/src/ui/misc/PlaceholderCard.tsx
+++ b/src/ui/misc/PlaceholderCard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
-import { Colors } from '../../styles';
+import { Colors, ComponentColors } from '../../styles';
 import { BoldText, RegularText } from './text';
 
 interface Props {
@@ -29,7 +29,7 @@ export const PlaceholderCard = (props: Props) => {
 const styles = StyleSheet.create({
     container: {
         backgroundColor: Colors.WHITE,
-        marginBottom: 20,
+        paddingBottom: 20,
     },
     textContainer: {
         paddingHorizontal: 20,
@@ -38,14 +38,14 @@ const styles = StyleSheet.create({
         textAlign: 'center',
         paddingTop: 10,
         fontSize: 14,
-        color: Colors.DARK_GRAY,
+        color: ComponentColors.TEXT_COLOR,
     },
     imageContainer: {
         marginTop: 10,
         alignItems: 'center',
     },
     topPlaceholder: {
-        backgroundColor: Colors.BACKGROUND_COLOR,
+        backgroundColor: ComponentColors.BACKGROUND_COLOR,
         height: 10,
     },
 });

--- a/src/ui/misc/TabBarPlaceholder.tsx
+++ b/src/ui/misc/TabBarPlaceholder.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { View, Platform } from 'react-native';
-import { DefaultTabBarHeight, Colors } from '../../styles';
+import { DefaultTabBarHeight, ComponentColors } from '../../styles';
 
 export const TabBarPlaceholder = (props: { color?: string }) => {
     if (Platform.OS === 'ios') {
@@ -8,7 +8,7 @@ export const TabBarPlaceholder = (props: { color?: string }) => {
             <View
                 style={{
                     height: DefaultTabBarHeight,
-                    backgroundColor: props.color ? props.color : Colors.BACKGROUND_COLOR,
+                    backgroundColor: props.color ? props.color : ComponentColors.BACKGROUND_COLOR,
                 }}
             />
         );

--- a/src/ui/screens/explore/CategoriesScreen.tsx
+++ b/src/ui/screens/explore/CategoriesScreen.tsx
@@ -7,6 +7,7 @@ import { NavigationHeader } from '../../../components/NavigationHeader';
 import { RowItem } from '../../misc/RowButton';
 import { TypedNavigation } from '../../../helpers/navigation';
 import { TabBarPlaceholder } from '../../misc/TabBarPlaceholder';
+import { FragmentSafeAreaView } from '../../misc/FragmentSafeAreaView';
 
 const CATEGORIES_LABEL = 'CATEGORIES';
 
@@ -34,16 +35,18 @@ export const CategoriesScreen = (props: StateProps & DispatchProps) => {
         );
     });
     return (
-        <SafeAreaView style={{ backgroundColor: ComponentColors.HEADER_COLOR, flex: 1 }}>
-            <NavigationHeader navigation={props.navigation} title='Explore'/>
-            <ScrollView style={{ backgroundColor: ComponentColors.BACKGROUND_COLOR }}>
-                <RegularText style={styles.label}>
-                    {CATEGORIES_LABEL}
-                </RegularText>
-                {categories}
-            </ScrollView>
-            <TabBarPlaceholder color={ComponentColors.BACKGROUND_COLOR}/>
-        </SafeAreaView>
+        <FragmentSafeAreaView>
+            <SafeAreaView style={{flex: 1}}>
+                <NavigationHeader navigation={props.navigation} title='Explore'/>
+                <ScrollView style={{ backgroundColor: ComponentColors.BACKGROUND_COLOR }}>
+                    <RegularText style={styles.label}>
+                        {CATEGORIES_LABEL}
+                    </RegularText>
+                    {categories}
+                </ScrollView>
+                <TabBarPlaceholder color={ComponentColors.BACKGROUND_COLOR}/>
+            </SafeAreaView>
+        </FragmentSafeAreaView>
     );
 };
 

--- a/src/ui/screens/explore/CategoriesScreen.tsx
+++ b/src/ui/screens/explore/CategoriesScreen.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { StyleSheet, ScrollView, SafeAreaView } from 'react-native';
-import { Colors } from '../../../styles';
+import { Colors, ComponentColors } from '../../../styles';
 import { RegularText } from '../../misc/text';
 import { Category } from '../../../models/recommendation/NewsSource';
 import { NavigationHeader } from '../../../components/NavigationHeader';
@@ -34,15 +34,15 @@ export const CategoriesScreen = (props: StateProps & DispatchProps) => {
         );
     });
     return (
-        <SafeAreaView style={{ backgroundColor: Colors.WHITE, flex: 1 }}>
+        <SafeAreaView style={{ backgroundColor: ComponentColors.HEADER_COLOR, flex: 1 }}>
             <NavigationHeader navigation={props.navigation} title='Explore'/>
-            <ScrollView style={{ backgroundColor: Colors.BACKGROUND_COLOR }}>
+            <ScrollView style={{ backgroundColor: ComponentColors.BACKGROUND_COLOR }}>
                 <RegularText style={styles.label}>
                     {CATEGORIES_LABEL}
                 </RegularText>
                 {categories}
             </ScrollView>
-            <TabBarPlaceholder color={Colors.BACKGROUND_COLOR}/>
+            <TabBarPlaceholder color={ComponentColors.BACKGROUND_COLOR}/>
         </SafeAreaView>
     );
 };

--- a/src/ui/screens/explore/NewsSourceGridScreen.tsx
+++ b/src/ui/screens/explore/NewsSourceGridScreen.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { FlatGrid } from 'react-native-super-grid';
 import { GridCard } from '../../misc/GridCard';
 import { ReactNativeModelHelper } from '../../../models/ReactNativeModelHelper';
-import { View, SafeAreaView, ActivityIndicator, StyleSheet } from 'react-native';
+import { View, ActivityIndicator, StyleSheet } from 'react-native';
 import { ComponentColors } from '../../../styles';
 import { NavigationHeader } from '../../../components/NavigationHeader';
 import { NewsSource } from '../../../models/recommendation/NewsSource';
@@ -11,6 +11,7 @@ import { Debug } from '../../../Debug';
 import { Feed } from '../../../models/Feed';
 import { TypedNavigation } from '../../../helpers/navigation';
 import { TabBarPlaceholder } from '../../misc/TabBarPlaceholder';
+import { FragmentSafeAreaView } from '../../misc/FragmentSafeAreaView';
 
 export interface StateProps {
     gatewayAddress: string;
@@ -37,7 +38,7 @@ export class NewsSourceGridScreen extends React.Component<StateProps & DispatchP
     public render() {
         const modelHelper = new ReactNativeModelHelper(this.props.gatewayAddress);
         return (
-            <SafeAreaView style={{ backgroundColor: ComponentColors.HEADER_COLOR, flex: 1 }}>
+            <FragmentSafeAreaView>
                 <NavigationHeader title={this.props.subCategoryName} navigation={this.props.navigation}/>
                 {this.state.feeds.length > 0 &&
                     <FlatGrid
@@ -71,7 +72,7 @@ export class NewsSourceGridScreen extends React.Component<StateProps & DispatchP
                     </View>
                 }
                 <TabBarPlaceholder color={ComponentColors.BACKGROUND_COLOR}/>
-            </SafeAreaView>
+            </FragmentSafeAreaView>
         );
     }
 

--- a/src/ui/screens/explore/NewsSourceGridScreen.tsx
+++ b/src/ui/screens/explore/NewsSourceGridScreen.tsx
@@ -3,7 +3,7 @@ import { FlatGrid } from 'react-native-super-grid';
 import { GridCard } from '../../misc/GridCard';
 import { ReactNativeModelHelper } from '../../../models/ReactNativeModelHelper';
 import { View, SafeAreaView, ActivityIndicator, StyleSheet } from 'react-native';
-import { Colors } from '../../../styles';
+import { ComponentColors } from '../../../styles';
 import { NavigationHeader } from '../../../components/NavigationHeader';
 import { NewsSource } from '../../../models/recommendation/NewsSource';
 import { RSSFeedManager } from '../../../RSSPostManager';
@@ -37,11 +37,11 @@ export class NewsSourceGridScreen extends React.Component<StateProps & DispatchP
     public render() {
         const modelHelper = new ReactNativeModelHelper(this.props.gatewayAddress);
         return (
-            <SafeAreaView style={{ backgroundColor: Colors.WHITE, flex: 1 }}>
+            <SafeAreaView style={{ backgroundColor: ComponentColors.HEADER_COLOR, flex: 1 }}>
                 <NavigationHeader title={this.props.subCategoryName} navigation={this.props.navigation}/>
                 {this.state.feeds.length > 0 &&
                     <FlatGrid
-                       style={{ flex: 1, backgroundColor: Colors.BACKGROUND_COLOR }}
+                       style={{ flex: 1, backgroundColor: ComponentColors.BACKGROUND_COLOR }}
                        spacing={10}
                        fixed={true}
                        itemDimension={170}
@@ -70,7 +70,7 @@ export class NewsSourceGridScreen extends React.Component<StateProps & DispatchP
                         <ActivityIndicator style={styles.activityIndicator} size='large'/>
                     </View>
                 }
-                <TabBarPlaceholder color={Colors.BACKGROUND_COLOR}/>
+                <TabBarPlaceholder color={ComponentColors.BACKGROUND_COLOR}/>
             </SafeAreaView>
         );
     }
@@ -114,10 +114,10 @@ const fetchRSSFeedFromUrl = async (url: string): Promise<Feed | null> => {
 const styles = StyleSheet.create({
     activityIndicatorContainer: {
         flex: 1,
-        backgroundColor: Colors.BACKGROUND_COLOR,
+        backgroundColor: ComponentColors.BACKGROUND_COLOR,
     },
     activityIndicator: {
         paddingTop: 30,
-        backgroundColor: Colors.BACKGROUND_COLOR,
+        backgroundColor: ComponentColors.BACKGROUND_COLOR,
     },
 });

--- a/src/ui/screens/explore/SubCategoriesScreen.tsx
+++ b/src/ui/screens/explore/SubCategoriesScreen.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { StyleSheet, ScrollView, SafeAreaView } from 'react-native';
-import { Colors } from '../../../styles';
+import { ComponentColors } from '../../../styles';
 import { RegularText } from '../../misc/text';
 import { SubCategory } from '../../../models/recommendation/NewsSource';
 import { NavigationHeader } from '../../../components/NavigationHeader';
@@ -37,15 +37,15 @@ export const SubCategoriesScreen = (props: StateProps & DispatchProps) => {
         );
     });
     return (
-        <SafeAreaView style={{ backgroundColor: Colors.WHITE, flex: 1 }}>
+        <SafeAreaView style={{ backgroundColor: ComponentColors.HEADER_COLOR, flex: 1 }}>
             <NavigationHeader title={props.title} navigation={props.navigation}/>
-            <ScrollView style={{ backgroundColor: Colors.BACKGROUND_COLOR }}>
+            <ScrollView style={{ backgroundColor: ComponentColors.BACKGROUND_COLOR }}>
                 <RegularText style={styles.label}>
                     {SUBCATEGORIES_LABEL}
                 </RegularText>
                 {subCategories}
             </ScrollView>
-            <TabBarPlaceholder color={Colors.BACKGROUND_COLOR}/>
+            <TabBarPlaceholder color={ComponentColors.BACKGROUND_COLOR}/>
         </SafeAreaView>
     );
 };
@@ -55,6 +55,6 @@ const styles = StyleSheet.create({
         paddingHorizontal: 10,
         paddingTop: 20,
         paddingBottom: 7,
-        color: Colors.GRAY,
+        color: ComponentColors.TEXT_COLOR,
     },
 });

--- a/src/ui/screens/explore/SubCategoriesScreen.tsx
+++ b/src/ui/screens/explore/SubCategoriesScreen.tsx
@@ -7,6 +7,7 @@ import { NavigationHeader } from '../../../components/NavigationHeader';
 import { RowItem } from '../../misc/RowButton';
 import { TypedNavigation } from '../../../helpers/navigation';
 import { TabBarPlaceholder } from '../../misc/TabBarPlaceholder';
+import { FragmentSafeAreaView} from '../../misc/FragmentSafeAreaView';
 
 const SUBCATEGORIES_LABEL = 'SUBCATEGORIES';
 
@@ -37,16 +38,18 @@ export const SubCategoriesScreen = (props: StateProps & DispatchProps) => {
         );
     });
     return (
-        <SafeAreaView style={{ backgroundColor: ComponentColors.HEADER_COLOR, flex: 1 }}>
-            <NavigationHeader title={props.title} navigation={props.navigation}/>
-            <ScrollView style={{ backgroundColor: ComponentColors.BACKGROUND_COLOR }}>
-                <RegularText style={styles.label}>
-                    {SUBCATEGORIES_LABEL}
-                </RegularText>
-                {subCategories}
-            </ScrollView>
-            <TabBarPlaceholder color={ComponentColors.BACKGROUND_COLOR}/>
-        </SafeAreaView>
+        <FragmentSafeAreaView>
+            <SafeAreaView style={{flex: 1}}>
+                <NavigationHeader title={props.title} navigation={props.navigation}/>
+                <ScrollView style={{ backgroundColor: ComponentColors.BACKGROUND_COLOR }}>
+                    <RegularText style={styles.label}>
+                        {SUBCATEGORIES_LABEL}
+                    </RegularText>
+                    {subCategories}
+                </ScrollView>
+                <TabBarPlaceholder color={ComponentColors.BACKGROUND_COLOR}/>
+            </SafeAreaView>
+        </FragmentSafeAreaView>
     );
 };
 

--- a/src/ui/screens/feed-settings/FeedSettingsScreen.tsx
+++ b/src/ui/screens/feed-settings/FeedSettingsScreen.tsx
@@ -8,7 +8,7 @@ import {
  } from 'react-native';
 
 import { Settings } from '../../../models/Settings';
-import { Colors } from '../../../styles';
+import { Colors, ComponentColors } from '../../../styles';
 import { NavigationHeader } from '../../../components/NavigationHeader';
 import { RowItem } from '../../../ui/misc/RowButton';
 import { ReactNativeModelHelper } from '../../../models/ReactNativeModelHelper';
@@ -41,12 +41,12 @@ export const FeedSettingsScreen = (props: Props) => {
         : defaultImages.userCircle
     ;
     return (
-        <SafeAreaView style={{ backgroundColor: Colors.WHITE, flex: 1 }}>
+        <SafeAreaView style={{ backgroundColor: ComponentColors.HEADER_COLOR, flex: 1 }}>
             <NavigationHeader
                 navigation={props.navigation}
                 title={props.feed.name}
             />
-            <ScrollView style={{ backgroundColor: Colors.BACKGROUND_COLOR, flex: 1 }}>
+            <ScrollView style={{ backgroundColor: ComponentColors.BACKGROUND_COLOR, flex: 1 }}>
                 <Image
                     source={source}
                     style={styles.image}
@@ -88,13 +88,13 @@ const styles = StyleSheet.create({
         paddingHorizontal: 10,
         paddingTop: 20,
         paddingBottom: 7,
-        color: Colors.GRAY,
+        color: ComponentColors.TEXT_COLOR,
     },
     explanation: {
         paddingHorizontal: 10,
         paddingTop: 20,
         paddingBottom: 7,
-        color: Colors.GRAY,
+        color: ComponentColors.TEXT_COLOR,
     },
     image: {
         width: 170,


### PR DESCRIPTION
Fixes #269 .

Changes proposed in this pull request:
- Separated `Colors` and `ComponentColors`. The formers are the base colors, the latter define the actual component colors which should be the same in the app. Ideally we should never use plain `Colors` and then re-styling would be easy.
- Added `FragmentSafeAreaView` with default styling. It makes the top area around the notch safe, but leaves the bottom as is. Therefore it's possible to use different styles for the top and bottom by using another `SafeAreaView` inside.
- Changed the menu icon and moved it to the left. It's a bit strange that the screens are still sliding from the right.
