### PR TITLE
Change add feed navigation

### DIFF
--- a/src/components/FeedView.tsx
+++ b/src/components/FeedView.tsx
@@ -121,12 +121,3 @@ const followFeed = (uri: string, feeds: Feed[], onFollowFeed: (feed: Feed) => vo
         onFollowFeed(knownFeed);
     }
 };
-
-const removeFeedAndGoBack = async (props: Props) => {
-    const confirmRemove = await AreYouSureDialog.show('Are you sure you want to delete?');
-    const feedToRemove = props.feeds.find(feed => feed.feedUrl === props.feedUrl && feed.followed !== true);
-    if (feedToRemove != null && confirmRemove) {
-        props.onRemoveFeed(feedToRemove);
-        props.onBack();
-    }
-};

--- a/src/containers/FeedContainer.ts
+++ b/src/containers/FeedContainer.ts
@@ -28,7 +28,7 @@ export const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNa
         : feedPosts
         ;
     return {
-        onBack: () => ownProps.navigation.goBack(null),
+        onBack: () => ownProps.navigation.popToTop(),
         navigation: ownProps.navigation,
         feedUrl,
         feedName,

--- a/src/helpers/navigation.ts
+++ b/src/helpers/navigation.ts
@@ -67,6 +67,7 @@ export interface TypedNavigation {
     goBack: <K extends keyof Routes>(routeKey?: K | null) => boolean;
     navigate: <K extends keyof Routes>(routeKey: K, params: Routes[K]) => boolean;
     pop: (n?: number, params?: { immediate?: boolean }) => boolean;
+    popToTop: () => void;
     getParam: <K extends keyof Routes, P extends keyof Routes[K]>(param: P) => K[P];
     setParams: <K extends keyof Routes>(newParams: Routes[K]) => boolean;
 }

--- a/test/components/CardTest.tsx
+++ b/test/components/CardTest.tsx
@@ -17,6 +17,7 @@ const mockNavigation: TypedNavigation = {
     goBack: (routeKey?: string | null) => true,
     navigate: (routeKey: any, params: any) => true,
     pop: (n?: number, params?: { immediate?: boolean }) => true,
+    popToTop: () => {},
     getParam: (param: any) => param.name,
     setParams: (newParams: any) => true,
 };


### PR DESCRIPTION
I tested the app a lot manually and this always bothered me:

When you added a new feed
1. You press the plus button (Home screen)
2. Enter the name of the feed (FeedInfo screen)
3. The app opened the feed view (FeedView screen)
4. You go back to the (FeedInfo screen)
5. You go back to the Home screen

Changes proposed in this pull request:
1. You press the plus button (Home screen)
2. Enter the name of the feed (FeedInfo screen)
3. The app opened the feed view (FeedView screen)
4. You go back to the Home screen
