### PR TITLE
Added auto fetch on app start

### DIFF
--- a/src/components/RefreshableFeed.tsx
+++ b/src/components/RefreshableFeed.tsx
@@ -7,7 +7,7 @@ import {
     LayoutAnimation,
 } from 'react-native';
 import { Post } from '../models/Post';
-import { ComponentColors } from '../styles';
+import { ComponentColors, Colors } from '../styles';
 import { StatusBarView } from './StatusBarView';
 import { Feed } from '../models/Feed';
 import { CardContainer } from '../containers/CardContainer';
@@ -88,6 +88,8 @@ export class RefreshableFeed extends React.PureComponent<Props, RefreshableFeedS
                             refreshing={this.state.isRefreshing}
                             onRefresh={() => this.onRefresh() }
                             progressViewOffset={HeaderOffset}
+                            tintColor={Colors.BRAND_PURPLE}
+                            colors={[Colors.BRAND_PURPLE]}
                         />
                     }
                     style={{

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -369,6 +369,8 @@ const initStore = () => {
     store.dispatch(Actions.timeTick());
     // @ts-ignore
     store.dispatch(AsyncActions.registerBackgroundTasks());
+    // @ts-ignore
+    store.dispatch(AsyncActions.downloadFollowedFeedPosts());
 
     setInterval(() => store.dispatch(Actions.timeTick()), 60000);
 };


### PR DESCRIPTION
Partially fixes #328 .

Changes proposed in this pull request:
- On app start automatically fetch the followed feeds
- I did not implement the spinner because it would take too much time now for a minor visual element
- Changed the color of the spinner to brand purple
