### PR TITLE
Fixed feed address deletion from clipboard

### DIFF
--- a/src/components/FeedInfo.tsx
+++ b/src/components/FeedInfo.tsx
@@ -76,7 +76,7 @@ export class FeedInfo extends React.Component<Props, FeedInfoState> {
         this.props.onAddFeed(feed);
     }
 
-    public async fetchFeed(onSuccess?: () => void, feedUrl?: string) {
+    public async fetchFeed(feedUrl?: string) {
         Debug.log('fetchFeed', 'this.state', this.state);
         if (this.state.loading === true) {
             return;
@@ -93,9 +93,6 @@ export class FeedInfo extends React.Component<Props, FeedInfoState> {
             this.setState({
                 loading: false,
             });
-            if (onSuccess != null) {
-                onSuccess();
-            }
             this.onAdd(feed);
             this.props.navigation.navigate('Feed', {
                 feedUrl: feed.feedUrl,
@@ -202,13 +199,14 @@ export class FeedInfo extends React.Component<Props, FeedInfoState> {
         const isExistingFeed = this.props.feed.feedUrl.length > 0;
         if (!isExistingFeed) {
             const value = await Clipboard.getString();
+            console.log('tryToAddFeedFromClipboard', {value});
             const link = urlUtils.getLinkFromText(value);
             if (link != null) {
                 this.setState({
                     url: link,
                 });
-                const clearClipboard = () => Clipboard.setString('');
-                await this.fetchFeed(clearClipboard, link);
+                Clipboard.setString('');
+                await this.fetchFeed(link);
             }
         }
     }
@@ -280,7 +278,7 @@ export class FeedInfo extends React.Component<Props, FeedInfoState> {
             this.setState({
                 url: feedUrl,
             });
-            await this.fetchFeed(undefined, feedUrl);
+            await this.fetchFeed(feedUrl);
         } catch (e) {
             Debug.log(e);
         }

--- a/src/helpers/urlUtils.ts
+++ b/src/helpers/urlUtils.ts
@@ -66,7 +66,7 @@ export const stripNonAscii = (s: string): string => {
 };
 
 export const getLinkFromText = (text: string): string | undefined => {
-    const httpLink = text.match(/(http.?:\/\/.*?\/)( |$)/);
+    const httpLink = text.match(/(http.?:\/\/.*?)( |$)/);
     if (httpLink != null) {
         return httpLink[1];
     }

--- a/test/UtilsTest.ts
+++ b/test/UtilsTest.ts
@@ -79,6 +79,14 @@ test('Test canonical url with path', () => {
     }
 });
 
+test('Test getLinkFromText with https link without trailing slash', () => {
+    const link = 'https://swarm-gateways.net';
+    const input = `Lorem ipsum ${link}`;
+    const result = urlUtils.getLinkFromText(input);
+
+    expect(result).toBe(link);
+});
+
 test('Test getLinkFromText with https link', () => {
     const link = 'https://swarm-gateways.net/';
     const input = `Lorem ipsum ${link}`;


### PR DESCRIPTION
Fixes #311 .

Changes proposed in this pull request:
- Feed address is deleted from clipboard after trying to add
- Works with urls without trailing slash too
