### PR TITLE
use correct timestamp for reshared post

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -153,6 +153,7 @@ const CardBody = (props: {
                             originalAuthorFeed={undefined}
                             togglePostSelection={undefined}
                             post={originalPost}
+                            currentTimestamp={originalPost.createdAt}
                             width={props.width - 22}
                         />
                     </View>


### PR DESCRIPTION
Fixes #392 

Changes proposed in this pull request:
- reshared post is using it's own createdAt timestamp