### PR TITLE
Fix post editor keyboard focus 183

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "react-native-qrcode-svg": "=5.1.1",
     "react-native-restart": "0.0.9",
     "react-native-securerandom": "=0.3.0",
-    "react-native-sortable-list": "0.0.23",
+    "react-native-sortable-list": "git+https://github.com/felfele/react-native-sortable-list",
     "react-native-splash-screen": "=3.2.0",
     "react-native-super-grid": "=3.0.1",
     "react-native-svg": "=8.0.8",

--- a/src/components/ImageDataView.tsx
+++ b/src/components/ImageDataView.tsx
@@ -17,7 +17,7 @@ export interface StateProps extends ImageProps {
 export interface DispatchProps {
 }
 
-export type Props = StateProps & DispatchProps & ChildrenProps;
+export type Props = StateProps & DispatchProps & Partial<ChildrenProps>;
 
 export interface State {
 }

--- a/src/components/ImagePreviewGrid.tsx
+++ b/src/components/ImagePreviewGrid.tsx
@@ -55,6 +55,7 @@ export class ImagePreviewGrid extends React.Component<Props> {
                 )}
                 // @ts-ignore needs d.ts update
                 onReleaseRow={this.props.onReleaseRow}
+                keyboardShouldPersistTaps='always'
             />
         );
     }

--- a/src/components/PostEditor.tsx
+++ b/src/components/PostEditor.tsx
@@ -9,6 +9,8 @@ import {
     StyleSheet,
     ActivityIndicator,
     Dimensions,
+    ScrollView,
+    Keyboard,
 } from 'react-native';
 import { AsyncImagePicker } from '../AsyncImagePicker';
 
@@ -55,6 +57,7 @@ interface State {
 export class PostEditor extends React.Component<Props, State> {
     public state: State;
     private modelHelper: ModelHelper;
+    private textInput: SimpleTextInput | null = null;
 
     constructor(props: Props) {
         super(props);
@@ -78,36 +81,39 @@ export class PostEditor extends React.Component<Props, State> {
 
         return (
             <FragmentSafeAreaViewWithoutTabBar>
+                <NavigationHeader
+                    leftButton={{
+                        onPress: this.onCancelConfirmation,
+                        label: <Icon
+                            name={'close'}
+                            size={20}
+                            color={ComponentColors.NAVIGATION_BUTTON_COLOR}
+                        />,
+                        testID: 'PostEditor/CloseButton',
+                    }}
+                    rightButton1={{
+                        onPress: sendButtonOnPress,
+                        label: sendIcon,
+                        testID: 'PostEditor/SendPostButton',
+                    }}
+                    titleImage={
+                        <Avatar
+                            size='medium'
+                            style={{ marginRight: 10 }}
+                            image={this.props.avatar}
+                            modelHelper={this.modelHelper}
+                        />
+                    }
+                    title={this.props.name}
+                />
                 <KeyboardAvoidingView
                     enabled={Platform.OS === 'ios'}
                     behavior='padding'
                     style={styles.container}
+                    // keyboardShouldPersistTaps='always'
+                    // keyboardDismissMode='none'
+                    // scrollEnabled={false}
                 >
-                    <NavigationHeader
-                        leftButton={{
-                            onPress: this.onCancelConfirmation,
-                            label: <Icon
-                                name={'close'}
-                                size={20}
-                                color={ComponentColors.NAVIGATION_BUTTON_COLOR}
-                            />,
-                            testID: 'PostEditor/CloseButton',
-                        }}
-                        rightButton1={{
-                            onPress: sendButtonOnPress,
-                            label: sendIcon,
-                            testID: 'PostEditor/SendPostButton',
-                        }}
-                        titleImage={
-                            <Avatar
-                                size='medium'
-                                style={{ marginRight: 10 }}
-                                image={this.props.avatar}
-                                modelHelper={this.modelHelper}
-                            />
-                        }
-                        title={this.props.name}
-                    />
                     <ImagePreviewGrid
                         images={this.state.post.images}
                         imageSize={Math.floor((windowWidth - GRID_SPACING * 4) / 3)}
@@ -120,6 +126,7 @@ export class PostEditor extends React.Component<Props, State> {
                                     images: order.map(i => this.state.post.images[i]),
                                 },
                             });
+                            this.focusTextInput();
                         }}
                     />
                     <SimpleTextInput
@@ -132,7 +139,9 @@ export class PostEditor extends React.Component<Props, State> {
                         placeholderTextColor='gray'
                         underlineColorAndroid='transparent'
                         autoFocus={true}
+                        blurOnSubmit={false}
                         testID='PostEditor/TextInput'
+                        ref={ref => this.textInput = ref}
                     />
                     <PhotoWidget onPressCamera={this.openCamera} onPressInsert={this.openImagePicker}/>
                 </KeyboardAvoidingView>
@@ -153,6 +162,7 @@ export class PostEditor extends React.Component<Props, State> {
         this.setState({
             post,
         });
+        this.focusTextInput();
     }
 
     private onChangeText = (text: string) => {
@@ -243,6 +253,13 @@ export class PostEditor extends React.Component<Props, State> {
             this.setState({
                 post,
             });
+        }
+        this.focusTextInput();
+    }
+
+    private focusTextInput = () => {
+        if (this.textInput != null) {
+            this.textInput.focus();
         }
     }
 

--- a/src/components/PostEditor.tsx
+++ b/src/components/PostEditor.tsx
@@ -9,8 +9,6 @@ import {
     StyleSheet,
     ActivityIndicator,
     Dimensions,
-    ScrollView,
-    Keyboard,
 } from 'react-native';
 import { AsyncImagePicker } from '../AsyncImagePicker';
 
@@ -110,9 +108,6 @@ export class PostEditor extends React.Component<Props, State> {
                     enabled={Platform.OS === 'ios'}
                     behavior='padding'
                     style={styles.container}
-                    // keyboardShouldPersistTaps='always'
-                    // keyboardDismissMode='none'
-                    // scrollEnabled={false}
                 >
                     <ImagePreviewGrid
                         images={this.state.post.images}

--- a/src/components/SimpleTextInput.tsx
+++ b/src/components/SimpleTextInput.tsx
@@ -23,6 +23,7 @@ interface SimpleTextInputProps {
     returnKeyType?: ReturnKeyTypeOptions;
     clearButtonMode?: 'never' | 'while-editing' | 'unless-editing' | 'always';
     editable?: boolean;
+    blurOnSubmit?: boolean;
 
     onSubmitEditing?: (text: string) => void;
     onChangeText?: (text: string) => void;
@@ -35,6 +36,8 @@ export class SimpleTextInput extends React.Component<SimpleTextInputProps, { tex
             ? this.props.defaultValue
             : '',
     };
+
+    private ref: TextInput | null = null;
 
     public render() {
         return (
@@ -66,8 +69,16 @@ export class SimpleTextInput extends React.Component<SimpleTextInputProps, { tex
                 onEndEditing={this.props.onEndEditing ? this.props.onEndEditing : this.onSubmitEditing}
                 clearButtonMode={this.props.clearButtonMode}
                 editable={this.props.editable}
+                blurOnSubmit={this.props.blurOnSubmit}
+                ref={ref => this.ref = ref}
             />
         );
+    }
+
+    public focus() {
+        if (this.ref != null) {
+            this.ref.focus();
+        }
     }
 
     private onSubmitEditing = () => {


### PR DESCRIPTION
Fixes #183 .

Changes proposed in this pull request:

    Set focus to the text input every time after it loses it
    Use forked react-native-sortable-list that supports keyboardShouldPersistTaps property
