### PR TITLE
Fixed navigation yellowbox warning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -361,9 +361,13 @@ const OnboardingNavigator = createStackNavigator({
     initialRouteName: 'Welcome',
 });
 
-const InitialNavigator = createSwitchNavigator({
+const LoadingNavigator = createStackNavigator({
     Loading: LoadingScreenContainer,
-    App: () => <AppNavigator uriPrefix={BASE_URL}/>,
+});
+
+const InitialNavigator = createSwitchNavigator({
+    Loading: LoadingNavigator,
+    App: AppNavigator,
     Onboarding: OnboardingNavigator,
 }, {
     initialRouteName: 'Loading',
@@ -376,7 +380,7 @@ export default class App extends React.Component {
             <TopLevelErrorBoundary>
                 <Provider store={store}>
                     <PersistGate loading={null} persistor={persistor}>
-                        <InitialNavigator/>
+                        <InitialNavigator uriPrefix={BASE_URL}/>
                     </PersistGate>
                 </Provider>
             </TopLevelErrorBoundary>


### PR DESCRIPTION
There was a yellowbox warning every time when starting the app. This is the proposed fix in the documentation:

https://reactnavigation.org/docs/en/common-mistakes.html#explicitly-rendering-more-than-one-navigator
