### PR TITLE
tryExpr helper function for helping avoiding try expressions

### DIFF
--- a/src/helpers/tryExpr.ts
+++ b/src/helpers/tryExpr.ts
@@ -1,0 +1,20 @@
+export const tryExpr = <T>(expr: () => T | never): T | Error => {
+    try {
+        return expr();
+    } catch (e) {
+        return e;
+    }
+};
+
+export const asyncTryExpr = async <T>(expr: () => Promise<T> | never): Promise<T | Error> => {
+    try {
+        const result = await expr();
+        return result;
+    } catch (e) {
+        return e;
+    }
+};
+
+export const isError = <T>(e: T | Error): e is Error => {
+    return e instanceof Error;
+};

--- a/test/helpers/tryExprTest.ts
+++ b/test/helpers/tryExprTest.ts
@@ -1,0 +1,65 @@
+import { tryExpr, asyncTryExpr, isError } from '../../src/helpers/tryExpr';
+
+test('successful expression with primitive type', () => {
+    const returnValue = 'hello';
+    const expr = () => returnValue;
+    const result = tryExpr(expr);
+
+    expect(result).toBe(returnValue);
+});
+
+test('successful expression with promise type', async () => {
+    const returnValue = 'hello';
+    const expr = () => Promise.resolve(returnValue);
+    const result = await tryExpr(expr);
+
+    expect(result).toBe(returnValue);
+});
+
+test('successful async expression with promise type', async () => {
+    const returnValue = 'hello';
+    const expr = () => Promise.resolve(returnValue);
+    const result = await asyncTryExpr(expr);
+
+    expect(result).toBe(returnValue);
+});
+
+test('expression throwing error', () => {
+    const error = new Error('error');
+    const expr = () => { throw error; };
+    const result = tryExpr(expr);
+
+    expect(result).toBe(error);
+});
+
+test('expression rejecting promise', async () => {
+    const error = new Error('error');
+    const expr = () => Promise.reject(error);
+    const result = await asyncTryExpr(expr);
+
+    expect(result).toBe(error);
+});
+
+test('successful expression with primitive type with isError', () => {
+    const returnValue = 'hello';
+    const expr = () => returnValue;
+    const result = tryExpr(expr);
+
+    expect(isError(result)).toBeFalsy();
+});
+
+test('expression throwing error with isError', () => {
+    const error = new Error('error');
+    const expr = () => { throw error; };
+    const result = tryExpr(expr);
+
+    expect(isError(result)).toBeTruthy();
+});
+
+test('expression rejecting promise', async () => {
+    const error = new Error('error');
+    const expr = () => Promise.reject(error);
+    const result = await asyncTryExpr(expr);
+
+    expect(isError(result)).toBeTruthy();
+});


### PR DESCRIPTION
Changes proposed in this pull request:
- Added helper functions that wraps try expressions
- With these control flow can be simplified, because `try .. catch` expressions can be completely avoided and error handling can be made explicit
