### PR TITLE
Bumped version to 1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.0.7 (2019-09-04) Beta release
+
+This release adds the following new features and fixes:
+- Feature: New contact tab with improved contact flow. Contacts are now the default, old follow based model is deprecated. (https://github.com/felfele/felfele/pull/505 and https://github.com/felfele/felfele/pull/497)
+- Feature: Private channels are synchronized in the background (https://github.com/felfele/felfele/pull/508)
+- Bugfix: iOS splash screen logo size (https://github.com/felfele/felfele/pull/504)
+
 ## v1.0.6 (2019-09-04) App Store release
 
 This release adds the following new features and fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.0.7 (2019-09-04) Beta release
+## v1.0.7 (2019-09-18) Beta release
 
 This release adds the following new features and fixes:
 - Feature: New contact tab with improved contact flow. Contacts are now the default, old follow based model is deprecated. (https://github.com/felfele/felfele/pull/505 and https://github.com/felfele/felfele/pull/497)

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -102,8 +102,8 @@ android {
 
     defaultConfig {
         applicationId "org.felfele.mobile"
-        versionCode 9
-        versionName "1.0.6"
+        versionCode 10
+        versionName "1.0.7"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         ndk {

--- a/ios/Felfele/Info.plist
+++ b/ios/Felfele/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.6</string>
+	<string>1.0.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>10</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true />
 	<key>NSAppTransportSecurity</key>

--- a/ios/Share/Info.plist
+++ b/ios/Share/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.6</string>
+	<string>1.0.7</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>10</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>
@@ -29,7 +29,7 @@
 				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
 				<integer>1</integer>
 				<key>NSExtensionActivationSupportsText</key>
-				<true/>
+				<true />
 			</dict>
 		</dict>
 		<key>NSExtensionMainStoryboard</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "felfele",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "devDependencies": {
     "@babel/core": "7.5.0",

--- a/src/Version.ts
+++ b/src/Version.ts
@@ -1,1 +1,1 @@
-export const Version = '1.0.6';
+export const Version = '1.0.7';


### PR DESCRIPTION
## v1.0.7 (2019-09-18) Beta release

This release adds the following new features and fixes:
- Feature: New contact tab with improved contact flow. Contacts are now the default, old follow based model is deprecated. (https://github.com/felfele/felfele/pull/505 and https://github.com/felfele/felfele/pull/497)
- Feature: Private channels are synchronized in the background (https://github.com/felfele/felfele/pull/508)
- Bugfix: iOS splash screen logo size (https://github.com/felfele/felfele/pull/504)
