### PR TITLE
improve post flow

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -112,7 +112,7 @@ const CardBody = (props: {
         ? authorFeed.isKnownFeed
             ? authorFeed.contact != null
                 ? () => props.navigation.navigate('ContactView', {
-                    publicKey: authorFeed.contact!.identity.publicKey,
+                    publicKey: authorFeed.contact.identity.publicKey,
                 })
                 : () => props.navigation.navigate('Feed', {
                     feedUrl: authorFeed.feedUrl,

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -30,8 +30,15 @@ import { Feed } from '../models/Feed';
 import { DEFAULT_AUTHOR_NAME } from '../reducers/defaultData';
 import { TypedNavigation } from '../helpers/navigation';
 import { ContactFeed } from '../models/ContactFeed';
+import { isContactFeed } from '../helpers/feedHelpers';
 
-export interface AuthorFeed extends ContactFeed {
+export type AuthorFeed = UIFeed | UIContactFeed;
+
+export interface UIFeed extends Feed {
+    isKnownFeed: boolean;
+}
+
+export interface UIContactFeed extends ContactFeed {
     isKnownFeed: boolean;
 }
 
@@ -110,7 +117,7 @@ const CardBody = (props: {
     const authorFeed = props.authorFeed;
     const cardTopOnPress = authorFeed != null
         ? authorFeed.isKnownFeed
-            ? authorFeed.contact != null
+            ? isContactFeed(authorFeed)
                 ? () => props.navigation.navigate('ContactView', {
                     publicKey: authorFeed.contact.identity.publicKey,
                 })

--- a/src/components/RefreshableFeed.tsx
+++ b/src/components/RefreshableFeed.tsx
@@ -14,15 +14,16 @@ import { Props as FeedHeaderProps } from './FeedHeader';
 import { ModelHelper } from '../models/ModelHelper';
 import { TypedNavigation } from '../helpers/navigation';
 import { FragmentSafeAreaViewWithoutTabBar } from '../ui/misc/FragmentSafeAreaView';
+import { ContactFeed } from '../models/ContactFeed';
 
 export interface DispatchProps {
-    onRefreshPosts: (feeds: Feed[]) => void;
+    onRefreshPosts: (feeds: Feed[] | ContactFeed[]) => void;
 }
 
 export interface StateProps {
     navigation: TypedNavigation;
     posts: Post[];
-    feeds: Feed[];
+    feeds: Feed[] | ContactFeed[];
     modelHelper: ModelHelper;
     children: {
         // WARNING, type parameter included for reference, but it does not typecheck

--- a/src/components/RefreshableFeed.tsx
+++ b/src/components/RefreshableFeed.tsx
@@ -17,13 +17,13 @@ import { FragmentSafeAreaViewWithoutTabBar } from '../ui/misc/FragmentSafeAreaVi
 import { ContactFeed } from '../models/ContactFeed';
 
 export interface DispatchProps {
-    onRefreshPosts: (feeds: Feed[] | ContactFeed[]) => void;
+    onRefreshPosts: (feeds: Array<Feed | ContactFeed>) => void;
 }
 
 export interface StateProps {
     navigation: TypedNavigation;
     posts: Post[];
-    feeds: Feed[] | ContactFeed[];
+    feeds: Array<Feed | ContactFeed>;
     modelHelper: ModelHelper;
     children: {
         // WARNING, type parameter included for reference, but it does not typecheck

--- a/src/containers/CardContainer.ts
+++ b/src/containers/CardContainer.ts
@@ -41,7 +41,7 @@ const getOriginalAuthorFeed = (post: Post, state: AppState): AuthorFeed | undefi
 };
 
 const getAuthorFeedOrUndefined = (
-    feed: ContactFeed | undefined
+    feed: ContactFeed | Feed | undefined
 ) => {
     return feed != null
         ? {

--- a/src/containers/PostEditorContainer.ts
+++ b/src/containers/PostEditorContainer.ts
@@ -5,6 +5,8 @@ import { Post } from '../models/Post';
 import { TypedNavigation } from '../helpers/navigation';
 import { Actions } from '../actions/Actions';
 import { Debug } from '../Debug';
+import { isContactFeed } from '../helpers/feedHelpers';
+import { AsyncActions } from '../actions/asyncActions';
 
 const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     const goBack = () => {
@@ -21,21 +23,29 @@ const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigatio
 };
 
 export const mapDispatchToProps = (dispatch: any, ownProps: { navigation: TypedNavigation }): DispatchProps => {
-   return {
-       onPost: (post: Post) => {
+    return {
+        onPost: (post: Post) => {
             const selectedFeeds = ownProps.navigation.getParam<'Post', 'selectedFeeds'>('selectedFeeds');
-            ownProps.navigation.navigate('ShareWithContainer', {
-                post,
-                selectedFeeds,
-            });
-       },
-       onSaveDraft: (draft: Post) => {
-           dispatch(Actions.addDraft(draft));
-       },
-       onDeleteDraft: () => {
-           dispatch(Actions.removeDraft());
-       },
-   };
+            const feed = selectedFeeds[0];
+            if (selectedFeeds.length === 1 && isContactFeed(feed)) {
+                dispatch(AsyncActions.shareWithContactFeeds(post, [feed]));
+                ownProps.navigation.navigate('ContactView', {
+                    publicKey: feed.contact.identity.publicKey,
+                });
+            } else {
+                ownProps.navigation.navigate('ShareWithContainer', {
+                    post,
+                    selectedFeeds,
+                });
+            }
+        },
+        onSaveDraft: (draft: Post) => {
+            dispatch(Actions.addDraft(draft));
+        },
+        onDeleteDraft: () => {
+            dispatch(Actions.removeDraft());
+        },
+    };
 };
 
 export const PostEditorContainer = connect(

--- a/src/models/ContactFeed.ts
+++ b/src/models/ContactFeed.ts
@@ -2,5 +2,5 @@ import { MutualContact } from './Contact';
 import { Feed } from './Feed';
 
 export interface ContactFeed extends Feed {
-    contact?: MutualContact;
+    contact: MutualContact;
 }

--- a/src/ui/screens/contact/ContactGrid.tsx
+++ b/src/ui/screens/contact/ContactGrid.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet, View, SafeAreaView } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { SuperGridSectionList } from 'react-native-super-grid';
 
 import { ContactFeed } from '../../../models/ContactFeed';
@@ -10,14 +10,15 @@ import { getFeedImage } from '../../../helpers/feedHelpers';
 import { defaultImages } from '../../../defaultImages';
 import { MediumText } from '../../misc/text';
 import { TabBarPlaceholder } from '../../misc/TabBarPlaceholder';
+import { Feed } from '../../../models/Feed';
 
 export interface DispatchProps {
-    onPressFeed: (feed: ContactFeed) => void;
+    onPressFeed: (feed: ContactFeed | Feed) => void;
 }
 
 export interface FeedSection {
     title?: string;
-    data: ContactFeed[];
+    data: ContactFeed[] | Feed [];
 }
 
 export interface StateProps {

--- a/src/ui/screens/contact/ContactGrid.tsx
+++ b/src/ui/screens/contact/ContactGrid.tsx
@@ -18,7 +18,7 @@ export interface DispatchProps {
 
 export interface FeedSection {
     title?: string;
-    data: ContactFeed[] | Feed [];
+    data: Array<Feed | ContactFeed>;
 }
 
 export interface StateProps {

--- a/src/ui/screens/contact/ContactViewContainer.ts
+++ b/src/ui/screens/contact/ContactViewContainer.ts
@@ -11,6 +11,7 @@ import { findContactByPublicKey, UnknownContact, deriveSharedKey } from '../../.
 import { Actions } from '../../../actions/Actions';
 import { Post } from '../../../models/Post';
 import { calculatePrivateTopic } from '../../../protocols/privateSharing';
+import { isContactFeed } from '../../../helpers/feedHelpers';
 
 const getContactPosts = (state: AppState, contact: MutualContact) => {
     const topic = calculatePrivateTopic(deriveSharedKey(state.author.identity!, contact.identity));
@@ -63,7 +64,7 @@ const mapDispatchToProps = (dispatch: any, ownProps: { navigation: TypedNavigati
             ownProps.navigation.popToTop();
         },
         onRefreshPosts: (feeds: Feed[]) => {
-            dispatch(AsyncActions.syncPrivatePostsWithContactFeeds(feeds));
+            dispatch(AsyncActions.syncPrivatePostsWithContactFeeds(feeds.filter(isContactFeed)));
         },
         onSaveDraft: (draft: Post) => {
             dispatch(Actions.addDraft(draft));

--- a/src/ui/screens/private-channels/PrivateChannelsContainer.ts
+++ b/src/ui/screens/private-channels/PrivateChannelsContainer.ts
@@ -8,6 +8,7 @@ import { DispatchProps } from '../../../components/RefreshableFeed';
 import { Post } from '../../../models/Post';
 import { Feed } from '../../../models/Feed';
 import { isContactFeed } from '../../../helpers/feedHelpers';
+import { ContactFeed } from '../../../models/ContactFeed';
 
 const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     const allPosts = getAllPrivateChannelPosts(state);
@@ -29,7 +30,7 @@ const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigatio
 
 const mapDispatchToProps = (dispatch: any): DispatchProps => {
     return {
-        onRefreshPosts: (feeds: Feed[]) => {
+        onRefreshPosts: (feeds: Array<Feed | ContactFeed>) => {
             dispatch(AsyncActions.advanceContacts());
             dispatch(AsyncActions.syncPrivatePostsWithContactFeeds(feeds.filter(isContactFeed)));
         },

--- a/src/ui/screens/private-channels/PrivateChannelsContainer.ts
+++ b/src/ui/screens/private-channels/PrivateChannelsContainer.ts
@@ -3,9 +3,11 @@ import { AppState } from '../../../reducers/AppState';
 import { AsyncActions } from '../../../actions/asyncActions';
 import { getPrivateChannelFeeds, getAllPrivateChannelPosts } from '../../../selectors/selectors';
 import { TypedNavigation } from '../../../helpers/navigation';
-import { StateProps, DispatchProps, PrivateChannelsFeedView } from './PrivateChannelsFeedView';
-import { ContactFeed } from '../../../models/ContactFeed';
+import { StateProps, PrivateChannelsFeedView } from './PrivateChannelsFeedView';
+import { DispatchProps } from '../../../components/RefreshableFeed';
 import { Post } from '../../../models/Post';
+import { Feed } from '../../../models/Feed';
+import { isContactFeed } from '../../../helpers/feedHelpers';
 
 const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation }): StateProps => {
     const allPosts = getAllPrivateChannelPosts(state);
@@ -27,9 +29,9 @@ const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigatio
 
 const mapDispatchToProps = (dispatch: any): DispatchProps => {
     return {
-        onRefreshPosts: (feeds: ContactFeed[]) => {
+        onRefreshPosts: (feeds: Feed[]) => {
             dispatch(AsyncActions.advanceContacts());
-            dispatch(AsyncActions.syncPrivatePostsWithContactFeeds(feeds));
+            dispatch(AsyncActions.syncPrivatePostsWithContactFeeds(feeds.filter(isContactFeed)));
         },
     };
 };

--- a/src/ui/screens/private-channels/PrivateChannelsFeedView.tsx
+++ b/src/ui/screens/private-channels/PrivateChannelsFeedView.tsx
@@ -3,17 +3,13 @@ import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 import { Feed } from '../../../models/Feed';
 import { Post } from '../../../models/Post';
-import { RefreshableFeed } from '../../../components/RefreshableFeed';
+import { RefreshableFeed, DispatchProps } from '../../../components/RefreshableFeed';
 import { NavigationHeader } from '../../../components/NavigationHeader';
 import { Colors, ComponentColors } from '../../../styles';
 import { ReactNativeModelHelper } from '../../../models/ReactNativeModelHelper';
 import { PlaceholderCard } from '../../misc/PlaceholderCard';
 import { TypedNavigation } from '../../../helpers/navigation';
 import { ContactFeed } from '../../../models/ContactFeed';
-
-export interface DispatchProps {
-    onRefreshPosts: (feeds: ContactFeed[]) => void;
-}
 
 export interface StateProps {
     navigation: TypedNavigation;

--- a/src/ui/screens/private-channels/PrivateChannelsFeedView.tsx
+++ b/src/ui/screens/private-channels/PrivateChannelsFeedView.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
-import { Feed } from '../../../models/Feed';
 import { Post } from '../../../models/Post';
 import { RefreshableFeed, DispatchProps } from '../../../components/RefreshableFeed';
 import { NavigationHeader } from '../../../components/NavigationHeader';

--- a/src/ui/screens/private-channels/PrivateChannelsListContainer.ts
+++ b/src/ui/screens/private-channels/PrivateChannelsListContainer.ts
@@ -4,7 +4,7 @@ import { AppState } from '../../../reducers/AppState';
 import { StateProps, DispatchProps, PrivateChannelsListView, FeedSection } from './PrivateChannelsListView';
 import { Feed } from '../../../models/Feed';
 import { TypedNavigation } from '../../../helpers/navigation';
-import { sortFeedsByName } from '../../../helpers/feedHelpers';
+import { sortFeedsByName, isContactFeed } from '../../../helpers/feedHelpers';
 import { ContactFeed } from '../../../models/ContactFeed';
 
 const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation, showExplore: boolean }): StateProps => {
@@ -31,10 +31,10 @@ const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigatio
 
 export const mapDispatchToProps = (dispatch: any, ownProps: { navigation: TypedNavigation }): DispatchProps => {
     return {
-        onPressChannel: (feed: ContactFeed) => {
-            if (feed.contact != null) {
+        onPressChannel: (feed: ContactFeed | Feed) => {
+            if (isContactFeed(feed)) {
                 ownProps.navigation.navigate('ContactView', {
-                    publicKey: feed.contact!.identity.publicKey,
+                    publicKey: feed.contact.identity.publicKey,
                 });
             } else {
                 ownProps.navigation.navigate('Feed', {

--- a/src/ui/screens/private-channels/PrivateChannelsListView.tsx
+++ b/src/ui/screens/private-channels/PrivateChannelsListView.tsx
@@ -16,7 +16,7 @@ export interface DispatchProps {
 
 export interface FeedSection {
     title?: string;
-    data: ContactFeed[] | Feed [];
+    data: Array<Feed | ContactFeed>;
 }
 
 export interface StateProps {

--- a/src/ui/screens/private-channels/PrivateChannelsListView.tsx
+++ b/src/ui/screens/private-channels/PrivateChannelsListView.tsx
@@ -7,15 +7,16 @@ import { ContactGrid } from '../contact/ContactGrid';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { ComponentColors } from '../../../styles';
 import { WideButton } from '../../buttons/WideButton';
+import { Feed } from '../../../models/Feed';
 
 export interface DispatchProps {
-    onPressChannel: (feed: ContactFeed) => void;
+    onPressChannel: (feed: ContactFeed | Feed) => void;
     onAddChannel: () => void;
 }
 
 export interface FeedSection {
     title?: string;
-    data: ContactFeed[];
+    data: ContactFeed[] | Feed [];
 }
 
 export interface StateProps {

--- a/src/ui/screens/public-channels/PublicChannelsListContainer.ts
+++ b/src/ui/screens/public-channels/PublicChannelsListContainer.ts
@@ -1,15 +1,13 @@
 import { connect } from 'react-redux';
 
 import { AppState } from '../../../reducers/AppState';
-import { StateProps, DispatchProps, PublicChannelsListView, FeedSection } from './PublicChannelsListView';
+import { StateProps, DispatchProps, PublicChannelsListView, PublicFeedSection } from './PublicChannelsListView';
 import { Feed } from '../../../models/Feed';
-import { getFollowedFeeds, getKnownFeeds, getContactFeeds } from '../../../selectors/selectors';
+import { getFollowedFeeds, getKnownFeeds } from '../../../selectors/selectors';
 import { TypedNavigation } from '../../../helpers/navigation';
 import { sortFeedsByName } from '../../../helpers/feedHelpers';
-import { Debug } from '../../../Debug';
-import { ContactFeed } from '../../../models/ContactFeed';
 
-const addSection = (title: string, feeds: Feed[]): FeedSection[] => {
+const addSection = (title: string, feeds: Feed[]): PublicFeedSection[] => {
     if (feeds.length > 0) {
         return [{
             title: `${title} (${feeds.length})`,
@@ -31,7 +29,7 @@ const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigatio
         : getKnownFeeds(state)
     );
 
-    const sections: FeedSection[] = ([] as FeedSection[]).concat(
+    const sections: PublicFeedSection[] = ([] as PublicFeedSection[]).concat(
         addSection('Public channels you follow', followedFeeds),
         addSection('Other channels', knownFeeds),
     );
@@ -50,16 +48,11 @@ export const mapDispatchToProps = (dispatch: any, ownProps: { navigation: TypedN
         openExplore: () => {
             ownProps.navigation.navigate('CategoriesContainer', {});
         },
-        onPressFeed: (feed: ContactFeed) => {
-            feed.contact != null
-                ? ownProps.navigation.navigate('ContactView', {
-                    publicKey: feed.contact.identity.publicKey,
-                })
-                : ownProps.navigation.navigate('FeedFromList', {
-                    feedUrl: feed.feedUrl,
-                    name: feed.name,
-                })
-            ;
+        onPressFeed: (feed: Feed) => {
+            ownProps.navigation.navigate('FeedFromList', {
+                feedUrl: feed.feedUrl,
+                name: feed.name,
+            });
         },
     };
 };

--- a/src/ui/screens/public-channels/PublicChannelsListView.tsx
+++ b/src/ui/screens/public-channels/PublicChannelsListView.tsx
@@ -15,21 +15,20 @@ import { TypedNavigation } from '../../../helpers/navigation';
 import { FragmentSafeAreaViewWithoutTabBar } from '../../../ui/misc/FragmentSafeAreaView';
 import { TwoButton } from '../../../ui/buttons/TwoButton';
 import { getFeedImage } from '../../../helpers/feedHelpers';
-import { ContactFeed } from '../../../models/ContactFeed';
 
 export interface DispatchProps {
-    onPressFeed: (feed: ContactFeed) => void;
+    onPressFeed: (feed: Feed) => void;
     openExplore: () => void;
 }
 
-export interface FeedSection {
+export interface PublicFeedSection {
     title?: string;
-    data: ContactFeed[];
+    data: Feed[];
 }
 
 export interface StateProps {
     navigation: TypedNavigation;
-    sections: FeedSection[];
+    sections: PublicFeedSection[];
     gatewayAddress: string;
     title: string;
     showExplore: boolean;

--- a/src/ui/screens/share-with/ShareWithContainer.ts
+++ b/src/ui/screens/share-with/ShareWithContainer.ts
@@ -3,12 +3,11 @@ import { connect } from 'react-redux';
 import { AppState } from '../../../reducers/AppState';
 import { StateProps, DispatchProps, ShareWithScreen, FeedSection } from './ShareWithScreen';
 import { TypedNavigation } from '../../../helpers/navigation';
-import { sortFeedsByName } from '../../../helpers/feedHelpers';
+import { sortFeedsByName, isContactFeed } from '../../../helpers/feedHelpers';
 import { ContactFeed } from '../../../models/ContactFeed';
 import { getContactFeeds } from '../../../selectors/selectors';
 import { AsyncActions } from '../../../actions/asyncActions';
 import { Post } from '../../../models/Post';
-import { Debug } from '../../../Debug';
 import { Feed } from '../../../models/Feed';
 
 const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigation, showExplore: boolean }): StateProps => {
@@ -37,16 +36,19 @@ const mapStateToProps = (state: AppState, ownProps: { navigation: TypedNavigatio
 const mapDispatchToProps = (dispatch: any, ownProps: { navigation: TypedNavigation }): DispatchProps => {
     return {
         onShareWithContacts: (post: Post, feeds: Feed[]) => {
-            const isContactFeed = (feed: Feed): feed is ContactFeed => (feed as ContactFeed).contact != null;
             const contactFeeds = feeds.filter(isContactFeed);
             dispatch(AsyncActions.shareWithContactFeeds(post, contactFeeds));
         },
-        onDoneSharing: () => {
+        onDoneSharing: (navigateTo?: () => void) => {
             const onDoneSharing = ownProps.navigation.getParam<'ShareWithContainer', 'onDoneSharing'>('onDoneSharing');
             if (onDoneSharing != null) {
                 onDoneSharing();
             }
-            ownProps.navigation.popToTop();
+            if (navigateTo != null) {
+                navigateTo();
+            } else {
+                ownProps.navigation.popToTop();
+            }
         },
     };
 };

--- a/src/ui/screens/share-with/ShareWithContainer.ts
+++ b/src/ui/screens/share-with/ShareWithContainer.ts
@@ -4,7 +4,6 @@ import { AppState } from '../../../reducers/AppState';
 import { StateProps, DispatchProps, ShareWithScreen, FeedSection } from './ShareWithScreen';
 import { TypedNavigation } from '../../../helpers/navigation';
 import { sortFeedsByName, isContactFeed } from '../../../helpers/feedHelpers';
-import { ContactFeed } from '../../../models/ContactFeed';
 import { getContactFeeds } from '../../../selectors/selectors';
 import { AsyncActions } from '../../../actions/asyncActions';
 import { Post } from '../../../models/Post';

--- a/src/ui/screens/share-with/ShareWithContainer.ts
+++ b/src/ui/screens/share-with/ShareWithContainer.ts
@@ -38,13 +38,23 @@ const mapDispatchToProps = (dispatch: any, ownProps: { navigation: TypedNavigati
             const contactFeeds = feeds.filter(isContactFeed);
             dispatch(AsyncActions.shareWithContactFeeds(post, contactFeeds));
         },
-        onDoneSharing: (navigateTo?: () => void) => {
+        onDoneSharing: (feeds: Feed[]) => {
             const onDoneSharing = ownProps.navigation.getParam<'ShareWithContainer', 'onDoneSharing'>('onDoneSharing');
             if (onDoneSharing != null) {
                 onDoneSharing();
             }
-            if (navigateTo != null) {
-                navigateTo();
+            const feed = feeds[0];
+            if (feeds.length === 1) {
+                if (isContactFeed(feed)) {
+                    ownProps.navigation.navigate('ContactView', {
+                        publicKey: feed.contact.identity.publicKey,
+                    });
+                } else {
+                    ownProps.navigation.navigate('Feed', {
+                        feedUrl: feed.feedUrl,
+                        name: feed.name,
+                    });
+                }
             } else {
                 ownProps.navigation.popToTop();
             }

--- a/src/ui/screens/share-with/ShareWithScreen.tsx
+++ b/src/ui/screens/share-with/ShareWithScreen.tsx
@@ -4,31 +4,27 @@ import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 import { ContactFeed } from '../../../models/ContactFeed';
 import { TypedNavigation } from '../../../helpers/navigation';
-import { FragmentSafeAreaViewWithoutTabBar, FragmentSafeAreaViewForTabBar } from '../../misc/FragmentSafeAreaView';
+import { FragmentSafeAreaViewForTabBar } from '../../misc/FragmentSafeAreaView';
 import { NavigationHeader } from '../../../components/NavigationHeader';
 import {
     ContactGrid,
-    StateProps as ContactGridStateProps,
-    DispatchProps as ContactGridDispatchProps,
 } from '../contact/ContactGrid';
 import { Post } from '../../../models/Post';
 import { removeFromArray } from '../../../helpers/immutable';
-import { WideButton } from '../../buttons/WideButton';
 import { Colors, ComponentColors } from '../../../styles';
-import { highestSeenLogicalTime } from '../../../protocols/timeline';
-import { Debug } from '../../../Debug';
 import { Feed } from '../../../models/Feed';
 import { RegularText, MediumText } from '../../misc/text';
 import { TouchableView } from '../../../components/TouchableView';
+import { isContactFeed } from '../../../helpers/feedHelpers';
 
 export interface DispatchProps {
-    onDoneSharing: () => void;
+    onDoneSharing: (navigateTo?: () => void) => void;
     onShareWithContacts: (post: Post, feed: Feed[]) => void;
 }
 
 export interface FeedSection {
     title?: string;
-    data: ContactFeed[];
+    data: ContactFeed[] | Feed[];
 }
 
 export interface StateProps {
@@ -153,6 +149,22 @@ export class ShareWithScreen extends React.Component<DispatchProps & StateProps,
             isSending: true,
         });
         this.props.onShareWithContacts(this.props.post, this.state.selectedFeeds);
-        this.props.onDoneSharing();
+        this.props.onDoneSharing(() => {
+            const feed = this.state.selectedFeeds[0];
+            if (this.state.selectedFeeds.length === 1) {
+                if (isContactFeed(feed)) {
+                    this.props.navigation.navigate('ContactView', {
+                        publicKey: feed.contact.identity.publicKey,
+                    });
+                } else {
+                    this.props.navigation.navigate('Feed', {
+                        feedUrl: feed.feedUrl,
+                        name: feed.name,
+                    });
+                }
+            } else {
+                this.props.navigation.popToTop();
+            }
+        });
     }
 }

--- a/src/ui/screens/share-with/ShareWithScreen.tsx
+++ b/src/ui/screens/share-with/ShareWithScreen.tsx
@@ -18,7 +18,7 @@ import { TouchableView } from '../../../components/TouchableView';
 import { isContactFeed } from '../../../helpers/feedHelpers';
 
 export interface DispatchProps {
-    onDoneSharing: (navigateTo?: () => void) => void;
+    onDoneSharing: (feeds: Feed[]) => void;
     onShareWithContacts: (post: Post, feed: Feed[]) => void;
 }
 
@@ -149,22 +149,6 @@ export class ShareWithScreen extends React.Component<DispatchProps & StateProps,
             isSending: true,
         });
         this.props.onShareWithContacts(this.props.post, this.state.selectedFeeds);
-        this.props.onDoneSharing(() => {
-            const feed = this.state.selectedFeeds[0];
-            if (this.state.selectedFeeds.length === 1) {
-                if (isContactFeed(feed)) {
-                    this.props.navigation.navigate('ContactView', {
-                        publicKey: feed.contact.identity.publicKey,
-                    });
-                } else {
-                    this.props.navigation.navigate('Feed', {
-                        feedUrl: feed.feedUrl,
-                        name: feed.name,
-                    });
-                }
-            } else {
-                this.props.navigation.popToTop();
-            }
-        });
+        this.props.onDoneSharing(this.state.selectedFeeds);
     }
 }

--- a/src/ui/screens/share-with/ShareWithScreen.tsx
+++ b/src/ui/screens/share-with/ShareWithScreen.tsx
@@ -24,7 +24,7 @@ export interface DispatchProps {
 
 export interface FeedSection {
     title?: string;
-    data: ContactFeed[] | Feed[];
+    data: Array<Feed | ContactFeed>;
 }
 
 export interface StateProps {


### PR DESCRIPTION
Changes proposed in this pull request:
- [x] if only one contact is selected when sharing, the app should navigate to the appropriate feed
- [x] if someone starts post editing from a private channel, it should be shared without the share dialog
